### PR TITLE
feat: route helium web streams through the proxy pool

### DIFF
--- a/lib/poller/job.go
+++ b/lib/poller/job.go
@@ -131,7 +131,7 @@ func (h HeliumJobCreator) createMultiPod(ctx context.Context, job []HeliumJob) e
 	// settings (-s): fixed fleet of two streams per target — one web, one
 	// mobile. Both poll direct (no proxy), IP-spoofed, with no inter-poll delay.
 	settings := []HeliumSetting{
-		{Mode: "web", Type: "held", Delay: 25, Proxy: false, SpoofIp: true},
+		{Mode: "web", Type: "held", Delay: 25, Proxy: true, SpoofIp: true},
 		{Mode: "mobile", Type: "held", Delay: 25, Proxy: false, SpoofIp: true, Token: token},
 	}
 	settingsData, err := json.Marshal(settings)


### PR DESCRIPTION
## Summary

Enables proxying for the helium **web** pollee stream.

The web stream setting changes `proxy:false` -> `proxy:true`, which tells
helium to route web polls through its **config proxy pool** (random pick
per request, from `ATOMI_APP__SEARCHER__PROXY`). The **mobile** stream is
unchanged — still direct + IP-spoofed.

## Notes
- Requires helium`s proxy pool (`ATOMI_APP__SEARCHER__PROXY`) to be
  populated for the landscape (via `pls update-proxy`); otherwise helium
  has no proxies to pick from.
- `spoofIp:true` is kept on the web stream, so requests still carry a
  spoofed `X-Real-IP` on top of the proxy egress.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Updated web stream proxy settings.
- All other stream configurations and mobile service behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->