### PR TITLE
perf: reuse a single pooled HTTP client for KTMB calls

### DIFF
--- a/lib/ktmb/http.go
+++ b/lib/ktmb/http.go
@@ -10,20 +10,21 @@ import (
 	"net/http"
 	u "net/url"
 	"strings"
+	"time"
 )
 
 type HttpConfig struct {
 	Url    string
 	Header map[string]string
 	logger *zerolog.Logger
-	proxy  *string
+	client *http.Client
 }
 
 type HttpClient[T any, Y any] struct {
 	Url    string
 	Header map[string]string
 	logger *zerolog.Logger
-	proxy  *string
+	client *http.Client
 }
 
 func NewHttp[T any, Y any](c HttpConfig) HttpClient[T, Y] {
@@ -31,7 +32,7 @@ func NewHttp[T any, Y any](c HttpConfig) HttpClient[T, Y] {
 		Url:    c.Url,
 		Header: c.Header,
 		logger: c.logger,
-		proxy:  c.proxy,
+		client: c.client,
 	}
 	return k
 }
@@ -71,26 +72,30 @@ func randomPublicIP() string {
 	}
 }
 
-func (k HttpClient[T, Y]) client() (*http.Client, error) {
-	if k.proxy == nil {
-		return &http.Client{}, nil
+// newHTTPClient builds a single reusable HTTP client with connection pooling
+// (keep-alive) tuned for the reserver's concurrent load. It is created once per
+// Ktmb and shared across every request and goroutine (http.Client/Transport are
+// safe for concurrent use), so TCP+TLS handshakes are amortized instead of paid
+// on every call. When a proxy list is configured, a random proxy is picked per
+// request via the transport's Proxy hook, so connections stay pooled per
+// (proxy, host) while still spreading load across proxies.
+func newHTTPClient(proxy *string) *http.Client {
+	transport := &http.Transport{
+		MaxIdleConns:          200,
+		MaxIdleConnsPerHost:   100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ForceAttemptHTTP2:     true,
 	}
-
-	proxies := strings.Split(*k.proxy, ";")
-	randomIndex := rand.Intn(len(proxies))
-	p := proxies[randomIndex]
-
-	pUrl, err := u.Parse(p)
-	if err != nil {
-		k.logger.Error().Err(err).Msg("Failed to parse URL")
-		return nil, err
+	if proxy != nil {
+		proxies := strings.Split(*proxy, ";")
+		transport.Proxy = func(*http.Request) (*u.URL, error) {
+			return u.Parse(strings.TrimSpace(proxies[rand.Intn(len(proxies))]))
+		}
 	}
-	proxy := http.ProxyURL(pUrl)
-	return &http.Client{
-		Transport: &http.Transport{
-			Proxy: proxy,
-		},
-	}, nil
+	return &http.Client{Transport: transport}
 }
 
 func (k HttpClient[T, Y]) Send(method string, path string, headers ...map[string]string) (Y, error) {
@@ -118,13 +123,7 @@ func (k HttpClient[T, Y]) Send(method string, path string, headers ...map[string
 
 	k.applyRealIP(req)
 
-	client, err := k.client()
-	if err != nil {
-		k.logger.Error().Err(err).Msg("Failed to create client")
-		return y, err
-	}
-
-	res, err := client.Do(req)
+	res, err := k.client.Do(req)
 	if err != nil {
 		k.logger.Error().Err(err).Msg("Failed to send request")
 		return y, err
@@ -187,13 +186,7 @@ func (k HttpClient[T, Y]) SendWith(method string, path string, payload T, header
 
 	k.applyRealIP(req)
 
-	client, err := k.client()
-	if err != nil {
-		k.logger.Error().Err(err).Msg("Failed to create client")
-		return y, err
-	}
-
-	res, err := client.Do(req)
+	res, err := k.client.Do(req)
 	if err != nil {
 		k.logger.Error().Err(err).Msg("Failed to send request")
 		return y, err
@@ -247,13 +240,7 @@ func (k HttpClient[T, Y]) BinarySendWith(method string, path string, payload T, 
 
 	k.applyRealIP(req)
 
-	client, err := k.client()
-	if err != nil {
-		k.logger.Error().Err(err).Msg("Failed to create client")
-		return nil, err
-	}
-
-	res, err := client.Do(req)
+	res, err := k.client.Do(req)
 	if err != nil {
 		k.logger.Error().Err(err).Msg("Failed to send request")
 		return nil, err

--- a/lib/ktmb/ktmb.go
+++ b/lib/ktmb/ktmb.go
@@ -1,6 +1,8 @@
 package ktmb
 
 import (
+	"net/http"
+
 	"github.com/rs/zerolog"
 )
 
@@ -9,7 +11,7 @@ type Ktmb struct {
 	AppUrl    string
 	Signature string
 	logger    *zerolog.Logger
-	proxy     *string
+	client    *http.Client
 }
 
 func New(apiUrl, appUrl string, ktmbSignature string, logger *zerolog.Logger, proxy *string) Ktmb {
@@ -29,7 +31,7 @@ func New(apiUrl, appUrl string, ktmbSignature string, logger *zerolog.Logger, pr
 		AppUrl:    appUrl,
 		Signature: ktmbSignature,
 		logger:    logger,
-		proxy:     p,
+		client:    newHTTPClient(p),
 	}
 }
 
@@ -49,7 +51,7 @@ func (k *Ktmb) NewApi() HttpConfig {
 			"requestSignature": k.Signature,
 		},
 		logger: k.logger,
-		proxy:  k.proxy,
+		client: k.client,
 	}
 }
 
@@ -61,7 +63,7 @@ func (k *Ktmb) NewApp() HttpConfig {
 			"requestSignature": k.Signature,
 		},
 		logger: k.logger,
-		proxy:  k.proxy,
+		client: k.client,
 	}
 }
 


### PR DESCRIPTION
## Summary

Makes KTMB HTTP calls reuse a single pooled client instead of building a
new `http.Client` + `http.Transport` on every request. This is the main
latency win for the reserver, which fires many concurrent reservations.

## Problem

`HttpClient.client()` ran per request:
- **Proxy path** created a brand-new `http.Transport` each call -> its own
  empty connection pool -> a full TCP + TLS handshake for *every* request.
- **No-proxy path** used `DefaultTransport`, whose `MaxIdleConnsPerHost`
  is just **2**, throttling connection reuse under concurrency.

## Change

Build one `*http.Client` per `Ktmb` (in `New`) and share it across all
requests and goroutines (`http.Client`/`Transport` are concurrency-safe):

- keep-alive pooling: `MaxIdleConns 200`, `MaxIdleConnsPerHost 100`
- `ForceAttemptHTTP2`, `IdleConnTimeout 90s`, `TLSHandshakeTimeout 10s`,
  `ResponseHeaderTimeout 30s` (bounds hung servers without cutting body
  transfers like the buyer`s ticket PDF)
- proxy list is still random-picked **per request** via the transport
  `Proxy` hook, so pooling is kept per (proxy, host) while load spreads

X-Real-IP spoofing is unchanged (per-request header, independent of the
reused connection).

## Other latency levers (not in this PR)

- Reserver concurrency is config-driven (`reserver.normalConcurrency`);
  with pooling now in place it can be raised more safely.
- Could add DNS caching / pre-warmed connections if KTMB DNS is slow.

## Verification
- `go build ./...` + `go vet ./lib/ktmb/...` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized HTTP request handling with improved connection management and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->