### PR TITLE
chore: reduce poller to 2 replicas

### DIFF
--- a/infra/root_chart/values.pichu.yaml
+++ b/infra/root_chart/values.pichu.yaml
@@ -134,7 +134,7 @@ poller:
   imagePullSecrets: []
   securityContext: *securityContext
   podSecurityContext: *podSecurityContext
-  replicaCount: 3
+  replicaCount: 2
   configMountPath: /app/config
 
   resources:

--- a/infra/root_chart/values.pikachu.yaml
+++ b/infra/root_chart/values.pikachu.yaml
@@ -135,7 +135,7 @@ poller:
   imagePullSecrets: []
   securityContext: *securityContext
   podSecurityContext: *podSecurityContext
-  replicaCount: 3
+  replicaCount: 2
   configMountPath: /app/config
 
   resources:

--- a/infra/root_chart/values.raichu.yaml
+++ b/infra/root_chart/values.raichu.yaml
@@ -135,7 +135,7 @@ poller:
   imagePullSecrets: []
   securityContext: *securityContext
   podSecurityContext: *podSecurityContext
-  replicaCount: 3
+  replicaCount: 2
   configMountPath: /app/config
 
   resources:


### PR DESCRIPTION
## Summary

Reduces the poller `replicaCount` from **3 to 2** in pichu, pikachu, and
raichu to lower resource usage. lapras (1) and the base default (1) are
unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted poller service replica count from 3 to 2 across multiple environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->