### PR TITLE
feat: poll the web stream stateless

### DIFF
--- a/lib/poller/job.go
+++ b/lib/poller/job.go
@@ -131,7 +131,7 @@ func (h HeliumJobCreator) createMultiPod(ctx context.Context, job []HeliumJob) e
 	// settings (-s): fixed fleet of two streams per target — one web, one
 	// mobile. Both poll direct (no proxy), IP-spoofed, with no inter-poll delay.
 	settings := []HeliumSetting{
-		{Mode: "web", Type: "held", Delay: 25, Proxy: true, SpoofIp: true},
+		{Mode: "web", Type: "stateless", Delay: 25, Proxy: true, SpoofIp: true},
 		{Mode: "mobile", Type: "held", Delay: 25, Proxy: false, SpoofIp: true, Token: token},
 	}
 	settingsData, err := json.Marshal(settings)


### PR DESCRIPTION
## Summary

Changes the helium **web** pollee stream `type` from `held` to
`stateless` (re-search each poll instead of caching a held token).
Mobile stays `held`.

## Stacking

This PR is **stacked on #21** (web -> proxy pool); its base branch is
`feat/enable-web-proxy`, so the two web-line edits compose with no
conflict. Net web stream: `type: stateless, proxy: true, spoofIp: true`.
Merge #21 first; GitHub will auto-retarget this PR to `main`.
