### PR TITLE
feat: helium web stateless and 120s poll duration

### DIFF
--- a/lib/poller/job.go
+++ b/lib/poller/job.go
@@ -131,7 +131,7 @@ func (h HeliumJobCreator) createMultiPod(ctx context.Context, job []HeliumJob) e
 	// settings (-s): fixed fleet of two streams per target — one web, one
 	// mobile. Both poll direct (no proxy), IP-spoofed, with no inter-poll delay.
 	settings := []HeliumSetting{
-		{Mode: "web", Type: "held", Delay: 25, Proxy: true, SpoofIp: true},
+		{Mode: "web", Type: "stateless", Delay: 25, Proxy: true, SpoofIp: true},
 		{Mode: "mobile", Type: "held", Delay: 25, Proxy: false, SpoofIp: true, Token: token},
 	}
 	settingsData, err := json.Marshal(settings)
@@ -193,7 +193,7 @@ func (h HeliumJobCreator) createMultiPod(ctx context.Context, job []HeliumJob) e
 					"-s",
 					string(settingsData),
 					"-i",
-					"180", // 3 minutes
+					"120", // 2 minutes
 				},
 				Resources: v1.ResourceRequirements{
 					Limits: v1.ResourceList{


### PR DESCRIPTION
## Summary

Two helium pollee changes (off latest main, after #21/#22 merged):

1. **Web stream -> stateless** (`type: held` -> `stateless`): re-search
   each poll instead of caching a held search token. Mobile stays `held`.
   Web stream is now `type: stateless, proxy: true, spoofIp: true`.
2. **Poll duration 180s -> 120s** (`-i 120`): each multi-watch run lasts
   2 minutes instead of 3, reducing overlap/load against the `@every 1m`
   cron. The dead `CreateJob` path is intentionally left at 180s.

Supersedes the old stateless PR #24 (which broke when #21 merged).

## Verification
- `go build ./...` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted polling interval from 3 minutes to 2 minutes for faster data updates.
  * Updated system configuration setting for improved operational behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->