### PR TITLE
fix: make enricher resilient and incremental

### DIFF
--- a/config/app/settings.yaml
+++ b/config/app/settings.yaml
@@ -71,6 +71,9 @@ enricher:
   userDataKey: ktmb:userData
   storeKey: ktmb:store
 
+  # ms between launching each per-slot enrichment (1 with IP rotation; was 16000)
+  delay: 1
+
 cdc:
   group: cdc
   scheme: http

--- a/infra/consumer_chart/app/settings.yaml
+++ b/infra/consumer_chart/app/settings.yaml
@@ -71,6 +71,9 @@ enricher:
   userDataKey: ktmb:userData
   storeKey: ktmb:store
 
+  # ms between launching each per-slot enrichment (1 with IP rotation; was 16000)
+  delay: 1
+
 cdc:
   group: cdc
   scheme: http

--- a/lib/enricher/enricher.go
+++ b/lib/enricher/enricher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
+	"sync"
 	"time"
 )
 
@@ -134,65 +135,101 @@ func (p *Enricher) enrich(ctx context.Context, tracer trace.Tracer) error {
 		return err
 	}
 
-	var store = make(FindStore)
+	// 1. Pull what we already have so the first pass only fetches missing slots.
+	cached := p.pullCache(ctx)
 
-	c := make(chan Find)
-	errC := make(chan error)
-
-	slots := 0
+	// Partition current demand: slots missing from cache (fetch first), slots we
+	// already have (seed from cache now, refresh second). Stale slots no longer
+	// in demand are dropped from the new store.
+	store := make(FindStore)
+	missing := make([]Find, 0)
+	existing := make([]Find, 0)
 	for dir, dirCount := range counts {
 		for date, dateCount := range dirCount {
-			for t, _ := range dateCount {
-				time.Sleep(16 * time.Second)
-				go func(ch chan Find, eCh chan error, dir, date, t string) {
-
-					d := lib.ZincToHeliumDate(date)
-
-					find, e := p.client.Find(userData, dir, d, t)
-					if e != nil {
-						p.logger.Error().Ctx(ctx).Err(e).
-							Str("dir", dir).
-							Str("date", date).
-							Str("time", t).
-							Msg("Failed to get find")
-						eCh <- e
-						return
-					}
-					ch <- Find{
-						Direction: dir,
-						Date:      date,
-						Time:      t,
-						Data:      find,
-					}
-				}(c, errC, dir, date, t)
-				slots = slots + 1
+			for t := range dateCount {
+				if fr, ok := getSlot(cached, dir, date, t); ok && fr.TripData != "" {
+					setSlot(store, dir, date, t, fr)
+					existing = append(existing, Find{Direction: dir, Date: date, Time: t})
+				} else {
+					missing = append(missing, Find{Direction: dir, Date: date, Time: t})
+				}
 			}
 		}
 	}
+	p.logger.Info().Ctx(ctx).Int("missing", len(missing)).Int("existing", len(existing)).
+		Msg("Partitioned demand against cache")
 
-	errs := make([]error, 0)
+	// Never wipe a good store on a transient empty-count read.
+	if len(missing) == 0 && len(existing) == 0 {
+		p.logger.Info().Ctx(ctx).Msg("No demand slots; leaving store unchanged")
+		return nil
+	}
 
-	for i := 0; i < slots; i++ {
-		select {
-		case find := <-c:
-			if _, ok := store[find.Direction]; !ok {
-				store[find.Direction] = map[string]map[string]FindRes{}
-			}
-			if _, ok := store[find.Direction][find.Date]; !ok {
-				store[find.Direction][find.Date] = map[string]FindRes{}
-			}
-			store[find.Direction][find.Date][find.Time] = find.Data
-		case e := <-errC:
-			p.logger.Error().Ctx(ctx).Err(e).Msg("Failed to get find")
-			errs = append(errs, e)
+	// 2. Top up the new/missing trips, then write so the reserver can act on the
+	//    fresh demand immediately.
+	p.fetchInto(ctx, store, userData, missing)
+	if err := p.write(ctx, tracer, userData, store); err != nil {
+		return err
+	}
+	p.logger.Info().Ctx(ctx).Int("slots", countSlots(store)).Msg("Wrote store (after top-up)")
+
+	// 3. Rotate (refresh) the slots we already had, then write again.
+	if len(existing) > 0 {
+		p.fetchInto(ctx, store, userData, existing)
+		if err := p.write(ctx, tracer, userData, store); err != nil {
+			return err
 		}
+		p.logger.Info().Ctx(ctx).Int("slots", countSlots(store)).Msg("Wrote store (after rotate)")
 	}
 
-	if len(errs) > 0 {
-		p.logger.Error().Ctx(ctx).Err(errs[0]).Msg("Failed to get find")
-		return errs[0]
-	}
+	return nil
+}
 
+// pullCache reads and decrypts the existing store. On miss or decrypt error it
+// returns an empty store so enrichment proceeds from scratch.
+func (p *Enricher) pullCache(ctx context.Context) FindStore {
+	enc, err := p.mainRedis.Get(ctx, p.enricher.StoreKey).Result()
+	if err != nil {
+		p.logger.Info().Ctx(ctx).Msg("No cached store; starting fresh")
+		return make(FindStore)
+	}
+	store, err := p.encryptor.DecryptAny(enc)
+	if err != nil {
+		p.logger.Error().Ctx(ctx).Err(err).Msg("Failed to decrypt cached store; starting fresh")
+		return make(FindStore)
+	}
+	return store
+}
+
+// fetchInto concurrently enriches the given slots into store. It is tolerant: a
+// slot whose Find fails is logged and skipped, never aborting the run. A
+// configurable delay (ms) paces request launches.
+func (p *Enricher) fetchInto(ctx context.Context, store FindStore, userData string, slots []Find) {
+	delay := time.Duration(p.enricher.Delay) * time.Millisecond
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, s := range slots {
+		time.Sleep(delay)
+		wg.Add(1)
+		go func(s Find) {
+			defer wg.Done()
+			d := lib.ZincToHeliumDate(s.Date)
+			find, e := p.client.Find(userData, s.Direction, d, s.Time)
+			if e != nil {
+				p.logger.Error().Ctx(ctx).Err(e).Str("dir", s.Direction).Str("date", s.Date).
+					Str("time", s.Time).Msg("Failed to get find (skipping slot)")
+				return
+			}
+			mu.Lock()
+			setSlot(store, s.Direction, s.Date, s.Time, find)
+			mu.Unlock()
+		}(s)
+	}
+	wg.Wait()
+}
+
+// write encrypts and persists userData + store, then signals the reserver.
+func (p *Enricher) write(ctx context.Context, tracer trace.Tracer, userData string, store FindStore) error {
 	ud, err := p.encryptor.Encrypt(userData)
 	if err != nil {
 		p.logger.Error().Ctx(ctx).Err(err).Msg("Failed to encrypt userData")
@@ -203,29 +240,45 @@ func (p *Enricher) enrich(ctx context.Context, tracer trace.Tracer) error {
 		p.logger.Error().Ctx(ctx).Err(err).Msg("Failed to encrypt store")
 		return err
 	}
-	p.logger.Info().Any("store", StoreToPublic(store)).Msg("Encrypted store")
-
-	udr, err := p.mainRedis.Set(ctx, p.enricher.UserDataKey, ud, 0).Result()
-	if err != nil {
-		p.logger.Error().Ctx(ctx).Err(err).Str("rediscmd", udr).Msg("Failed to set userData")
+	if _, err := p.mainRedis.Set(ctx, p.enricher.UserDataKey, ud, 0).Result(); err != nil {
+		p.logger.Error().Ctx(ctx).Err(err).Msg("Failed to set userData")
 		return err
 	}
-	p.logger.Info().Ctx(ctx).Msgf("Set userData: %s", udr)
-
-	sr, err := p.mainRedis.Set(ctx, p.enricher.StoreKey, storeEn, 0).Result()
-	if err != nil {
-		p.logger.Error().Ctx(ctx).Err(err).Str("rediscmd", sr).Msg("Failed to set store")
+	if _, err := p.mainRedis.Set(ctx, p.enricher.StoreKey, storeEn, 0).Result(); err != nil {
+		p.logger.Error().Ctx(ctx).Err(err).Msg("Failed to set store")
 		return err
 	}
-	p.logger.Info().Ctx(ctx).Msgf("Set store: %s", sr)
-
-	// we should emit for reserver to sync up
-	p.logger.Info().Ctx(ctx).Msg("Emitting for reserver to sync up")
-
-	add, err := p.streamRedis.StreamAdd(ctx, tracer, p.stream.Enrich, "ping")
-	if err != nil {
-		p.logger.Error().Ctx(ctx).Err(err).Str("rediscmd", add.String()).Msg("Failed to add to stream")
+	if _, err := p.streamRedis.StreamAdd(ctx, tracer, p.stream.Enrich, "ping"); err != nil {
+		p.logger.Error().Ctx(ctx).Err(err).Msg("Failed to emit enrich signal")
 		return err
 	}
 	return nil
+}
+
+func getSlot(s FindStore, dir, date, t string) (FindRes, bool) {
+	if s[dir] == nil || s[dir][date] == nil {
+		return FindRes{}, false
+	}
+	fr, ok := s[dir][date][t]
+	return fr, ok
+}
+
+func setSlot(s FindStore, dir, date, t string, fr FindRes) {
+	if s[dir] == nil {
+		s[dir] = map[string]map[string]FindRes{}
+	}
+	if s[dir][date] == nil {
+		s[dir][date] = map[string]FindRes{}
+	}
+	s[dir][date][t] = fr
+}
+
+func countSlots(s FindStore) int {
+	n := 0
+	for _, dd := range s {
+		for _, tt := range dd {
+			n += len(tt)
+		}
+	}
+	return n
 }

--- a/system/config/model.go
+++ b/system/config/model.go
@@ -102,6 +102,11 @@ type EnricherConfig struct {
 
 	UserDataKey string
 	StoreKey    string
+
+	// Delay is the pause (in milliseconds) between launching each per-slot
+	// enrichment request. With X-Real-IP rotation defeating the rate limiter
+	// this can be ~1ms; it was 16000 (16s) before rotation existed.
+	Delay int
 }
 
 // Poller


### PR DESCRIPTION
## Summary

Fixes the root cause of the reserver "Trip data is empty" failures.

## Root cause (confirmed against raichu Redis)

Encryption/storage are healthy (`ktmb:userData` + `ktmb:store` decrypt
fine, 49 slots, 0 empty). But the store was **3+ days stale** (it still
contained past dates). The enricher write is at the very end of a long
sequential run, and **any single slot Find error bubbles up through
`loop()` -> `Start()` and exits the process** (enricher.go:83-87 +
191-193). So the store only persisted if all ~49 slots succeeded in one
uninterrupted run -- and with 16s/slot that run was ~13 min and one
sold-out/transient failure crashed it before the write.

## Changes

- **Pull from cache, then incremental two-phase write:**
  1. read existing store; partition demand into *missing* vs *existing*
  2. fetch missing -> **write** (new demand live immediately)
  3. rotate/refresh existing -> **write**
- **Tolerant fetch:** a slot whose `Find` fails is logged and skipped; it
  never aborts the run or crashes the process.
- **Configurable delay:** `enricher.delay` (ms), default **1** (was a
  hardcoded 16000ms; X-Real-IP rotation defeats the rate limiter so the
  pacing is no longer needed).
- **Safety:** never overwrite a good store with an empty one on a
  transient empty-count read.

Net: the store self-heals, stays fresh, and survives partial failures.

## Verification
- `go build ./...` + `go vet` clean.
- Confirmed the stale/healthy-encryption diagnosis by decrypting raichu
  `ktmb:store` directly (read-only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable enrichment delay timing setting for flexible performance optimization (default value reduced from 16000ms to 1ms for faster processing)

* **Refactor**
  * Optimized enrichment workflow with intelligent caching system to eliminate redundant data processing and reduce overall computational overhead
  * Enhanced concurrent request handling with improved resilience to maintain system reliability during enrichment operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->