### PR TITLE
feat: failure-log context + single 10ms mobile helium stream

### DIFF
--- a/lib/buyer/buyer.go
+++ b/lib/buyer/buyer.go
@@ -23,7 +23,7 @@ func NewBuyer(k ktmb.Ktmb, logger *zerolog.Logger, contactNumber string, sleepBu
 	}
 }
 
-func (c *Buyer) Buy(userData, bookingData string, p Passenger) ([]byte, string, string, error) {
+func (c *Buyer) Buy(userData, bookingData string, p Passenger, direction, date, t string) ([]byte, string, string, error) {
 
 	sd := time.Duration(c.sleepBuffer) * time.Second
 	c.logger.Info().Msg("Initialize booking...")
@@ -69,13 +69,13 @@ func (c *Buyer) Buy(userData, bookingData string, p Passenger) ([]byte, string, 
 		},
 	})
 	if err != nil {
-		c.logger.Error().Err(err).Msg("Failed to set passenger")
+		c.logger.Error().Err(err).Str("date", date).Str("time", t).Str("dir", direction).Msg("Failed to set passenger")
 		return nil, "", "", err
 	}
 
 	if !passenger.Status {
 		e := fmt.Errorf("failed to set passenger: %+v", passenger.Messages)
-		c.logger.Error().Err(e).Strs("errors", passenger.Messages).Msg("Failed to set passenger")
+		c.logger.Error().Err(e).Strs("errors", passenger.Messages).Str("date", date).Str("time", t).Str("dir", direction).Msg("Failed to set passenger")
 		return nil, "", "", e
 	}
 

--- a/lib/buyer/client.go
+++ b/lib/buyer/client.go
@@ -128,7 +128,7 @@ func (c *Client) loop(ctx context.Context) (bool, error) {
 		c.logger.Info().Any("reserveDto", reserveDto).Ctx(ctx).Msg("Reserver emitted signal decrypted")
 		er := c.buy(ctx, reserveDto.Direction, reserveDto.Date, reserveDto.Time, reserveDto.UserData, reserveDto.BookingData)
 		if er != nil {
-			c.logger.Error().Err(er).Msg("Failed to buy")
+			c.logger.Error().Err(er).Str("date", reserveDto.Date).Str("time", reserveDto.Time).Str("dir", reserveDto.Direction).Msg("Failed to buy")
 			return er
 		}
 		return nil
@@ -204,9 +204,9 @@ func (c *Client) buy(ctx context.Context, direction, date, t, userData, bookingD
 	}
 
 	c.logger.Info().Any("passenger", p).Msg("Passenger")
-	buy, bookingNo, ticketNo, err := c.buyer.Buy(userData, bookingData, p)
+	buy, bookingNo, ticketNo, err := c.buyer.Buy(userData, bookingData, p, direction, date, t)
 	if err != nil {
-		c.logger.Error().Err(err).Msg("failed to buy")
+		c.logger.Error().Err(err).Str("date", date).Str("time", t).Str("dir", direction).Msg("failed to buy")
 		return err
 	}
 

--- a/lib/poller/job.go
+++ b/lib/poller/job.go
@@ -128,11 +128,10 @@ func (h HeliumJobCreator) createMultiPod(ctx context.Context, job []HeliumJob) e
 		return err
 	}
 
-	// settings (-s): fixed fleet of two streams per target — one web, one
-	// mobile. Both poll direct (no proxy), IP-spoofed, with no inter-poll delay.
+	// settings (-s): a single mobile stream per target — IP-spoofed, held
+	// (cached search token), polling at a 10ms inter-poll delay.
 	settings := []HeliumSetting{
-		{Mode: "web", Type: "stateless", Delay: 25, Proxy: true, SpoofIp: true},
-		{Mode: "mobile", Type: "held", Delay: 25, Proxy: false, SpoofIp: true, Token: token},
+		{Mode: "mobile", Type: "held", Delay: 10, Proxy: false, SpoofIp: true, Token: token},
 	}
 	settingsData, err := json.Marshal(settings)
 	if err != nil {

--- a/lib/reserver/reserver.go
+++ b/lib/reserver/reserver.go
@@ -281,12 +281,12 @@ func (c *Client) reserve(ctx context.Context, direction, date, t, userData, sear
 
 	reserve, err := c.ktmb.Reserve(userData, c.appInfo, searchData, tripData)
 	if err != nil {
-		c.logger.Error().Err(err).Msg("Failed to reserve")
+		c.logger.Error().Err(err).Str("date", date).Str("time", t).Str("dir", direction).Msg("Failed to reserve")
 		return err
 	}
 	if !reserve.Status {
 		e := fmt.Errorf("failed to reserve")
-		c.logger.Error().Err(e).Strs("errors", reserve.Messages).Msg("Failed to reserve")
+		c.logger.Error().Err(e).Strs("errors", reserve.Messages).Str("date", date).Str("time", t).Str("dir", direction).Msg("Failed to reserve")
 		return e
 	}
 


### PR DESCRIPTION
## Summary

Two unrelated-but-bundled changes.

### 1. Failure-log context
Add `date`, `time`, `dir` to logs that lacked booking context:
- **`Failed to reserve`** (`lib/reserver/reserver.go`, both logs in `reserve()`)
- **`failed to buy`** (`lib/buyer/client.go`, outer + inner)
- **`Failed to set passenger`** (`lib/buyer/buyer.go`) — threaded
  `direction/date/t` into `Buyer.Buy(...)` and tagged both logs.

### 2. Helium polling
- **Remove the web pollee stream** — keep only the IP-spoofed `mobile`
  stream per target.
- **Inter-poll delay 25ms → 10ms.**

No behaviour change beyond the above. `go build ./...` + `go vet` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worker jobs now run a single mobile-style stream per target with reduced delay, IP spoofing enabled and mobile token usage — improving responsiveness for mobile flows.

* **Chores**
  * Enhanced internal error logging with added contextual fields for better tracing.
  * Updated method parameters to propagate transaction context across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->