### PR TITLE
fix(buyer): match KTMB's real duplicate-passport wording

### DIFF
--- a/config/app/settings.yaml
+++ b/config/app/settings.yaml
@@ -40,6 +40,12 @@ buyer:
   completeRetries: 5
   parkRetries: 5
   conflictPatterns:
+    # KTMB's actual SetPassenger message is "Duplicated passport number for
+    # onward trip : <passport>." — note "Duplicated", not "duplicate", so the
+    # old 'duplicate passport' substring never matched and conflicts fell
+    # through to the generic-error path (booking stranded in Buying, never
+    # parked for recovery). Match the real wording; keep the old one too.
+    - 'duplicated passport'
     - 'duplicate passport'
 
 terminator:

--- a/infra/consumer_chart/app/settings.yaml
+++ b/infra/consumer_chart/app/settings.yaml
@@ -40,6 +40,12 @@ buyer:
   completeRetries: 5
   parkRetries: 5
   conflictPatterns:
+    # KTMB's actual SetPassenger message is "Duplicated passport number for
+    # onward trip : <passport>." — note "Duplicated", not "duplicate", so the
+    # old 'duplicate passport' substring never matched and conflicts fell
+    # through to the generic-error path (booking stranded in Buying, never
+    # parked for recovery). Match the real wording; keep the old one too.
+    - 'duplicated passport'
     - 'duplicate passport'
 
 terminator:

--- a/lib/buyer/errors.go
+++ b/lib/buyer/errors.go
@@ -6,7 +6,8 @@ import (
 )
 
 // ConflictError marks a KTMB rejection that means this passenger already holds
-// a ticket for the slot (e.g. "duplicate passport" at SetPassenger). The
+// a ticket for the slot. KTMB's SetPassenger wording is "Duplicated passport
+// number for onward trip : <passport>." (matched via conflictPatterns). The
 // booking should be parked for recovery instead of crash-looping the buyer.
 type ConflictError struct {
 	Messages []string

--- a/lib/buyer/errors_test.go
+++ b/lib/buyer/errors_test.go
@@ -3,13 +3,17 @@ package buyer
 import "testing"
 
 func TestMatchesConflict(t *testing.T) {
-	patterns := []string{"duplicate passport"}
+	// mirror the deployed config (config/app + infra/consumer_chart settings.yaml)
+	patterns := []string{"duplicated passport", "duplicate passport"}
 
 	cases := []struct {
 		name     string
 		messages []string
 		want     bool
 	}{
+		// the real KTMB SetPassenger rejection — the string this fix exists for
+		{"real ktmb onward-trip message", []string{"Duplicated passport number for onward trip : K4461909G."}, true},
+		{"real ktmb return-trip variant", []string{"Duplicated passport number for return trip : A1234567."}, true},
 		{"duplicate passport message", []string{"Duplicate passport no. found in the same trip."}, true},
 		{"case insensitive", []string{"DUPLICATE PASSPORT NO."}, true},
 		{"unrelated error", []string{"Session expired"}, false},
@@ -24,6 +28,19 @@ func TestMatchesConflict(t *testing.T) {
 				t.Errorf("matchesConflict(%v) = %v, want %v", tc.messages, got, tc.want)
 			}
 		})
+	}
+}
+
+// regression guard: the OLD pattern alone must NOT match KTMB's real wording —
+// this is the exact bug (extra 'd' in "Duplicated") that stranded conflicts in
+// Buying. If someone drops 'duplicated passport', this test fails loudly.
+func TestOldPatternMissesRealKtmbMessage(t *testing.T) {
+	real := []string{"Duplicated passport number for onward trip : K4461909G."}
+	if matchesConflict([]string{"duplicate passport"}, real) {
+		t.Fatal("'duplicate passport' unexpectedly matched the real KTMB message; the 'duplicated passport' pattern would be redundant")
+	}
+	if !matchesConflict([]string{"duplicated passport"}, real) {
+		t.Fatal("'duplicated passport' must match the real KTMB message")
 	}
 }
 


### PR DESCRIPTION
## Problem
KTMB's `SetPassenger` rejection message is:
> `Duplicated passport number for onward trip : K4461909G.`

But `buyer.conflictPatterns` only had `'duplicate passport'` — which is **not** a substring of `"Duplicated passport"` (the extra **d** in Duplicate**d** breaks the case-insensitive substring match).

## Impact (prod, raichu)
Since the 1.44.0 deploy at **2026-07-03 21:01 UTC**, every duplicate-passport conflict fell through to the generic error path (`buyer.go:90`):
- no `ConflictError` raised → `park()` never called
- booking left in **`Buying`**, never moved to `Recovering`, never enqueued
- money held, nothing to recover

Confirmed in prod logs at 01:17 / 01:31 / 01:57 UTC on 07-04 — all `Failed to set passenger: [Duplicated passport number ...]`, none parked.

## Fix
Add `'duplicated passport'` to `conflictPatterns` (keep the old one as belt-and-suspenders). Match is case-insensitive substring, so conflicts now correctly park into `Recovering`.

```yaml
buyer:
  conflictPatterns:
    - 'duplicated passport'
    - 'duplicate passport'
```

## Verify after deploy
Watch buyer logs for `Passenger conflict detected (duplicate passport)` + `Duplicate-passenger conflict, parking booking for recovery` on the next duplicate, and confirm the recover queue length goes > 0.

https://claude.ai/code/session_01Xyb9Y7aiWqGwGbtXRAL3ES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conflict detection for buyer passport issues by recognizing an additional message variant, reducing cases that fell through to a generic error.
  * Increased matching reliability for KTMB-style conflict messages with different wording/capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->