### PR TITLE
feat(buyer): auto-revert to Pending on transient wallet-insufficient failure

### DIFF
--- a/cmds/buyer.go
+++ b/cmds/buyer.go
@@ -37,7 +37,7 @@ func (state *State) Buyer(c *cli.Context) error {
 
 	recoverEncr := encryptor.NewSymEncryptor[lib.RecoverDto](state.Config.Encryptor.Key, state.Logger)
 
-	b := buyer.NewBuyer(k, state.Logger, state.Config.Buyer.ContactNumber, state.Config.Buyer.SleepBuffer, state.Config.Buyer.ConflictPatterns)
+	b := buyer.NewBuyer(k, state.Logger, state.Config.Buyer.ContactNumber, state.Config.Buyer.SleepBuffer, state.Config.Buyer.ConflictPatterns, state.Config.Buyer.RevertPatterns)
 	client := buyer.New(&b, &mainRedis, &streamRedis, state.OtelConfigurator, state.Logger, state.Config.Stream, state.Config.Buyer,
 		state.Config.Recoverer, state.Psm, zClient, encr, recoverEncr)
 

--- a/cmds/recoverer.go
+++ b/cmds/recoverer.go
@@ -48,7 +48,7 @@ func (state *State) buildRecoverer() (*recoverer.Client, *zinc.Client, error) {
 	s := session.New(&k, &mainRedis, state.Logger, state.Config.Ktmb.LoginKey, loginEncr)
 	retriever := reserver.NewRetriever(&mainRedis, findEncr, state.Logger, state.Config.Enricher)
 
-	b := buyer.NewBuyer(k, state.Logger, buyerCfg.ContactNumber, buyerCfg.SleepBuffer, buyerCfg.ConflictPatterns)
+	b := buyer.NewBuyer(k, state.Logger, buyerCfg.ContactNumber, buyerCfg.SleepBuffer, buyerCfg.ConflictPatterns, buyerCfg.RevertPatterns)
 
 	client := recoverer.New(k, &b, &s, retriever, &mainRedis, zClient, recoverEncr, state.OtelConfigurator,
 		state.Logger, state.Config.Recoverer, state.Config.Enricher, state.Psm, ktmbAppInfo, state.Location)

--- a/config/app/settings.yaml
+++ b/config/app/settings.yaml
@@ -47,6 +47,11 @@ buyer:
     # parked for recovery). Match the real wording; keep the old one too.
     - 'duplicated passport'
     - 'duplicate passport'
+  # KTMB error substrings that mean a transient, ticket-less buy failure — the
+  # buyer reverts these bookings Buying -> Pending to retry (e.g. the KTMB
+  # e-wallet ran out of funds at Pay: "KTM Wallet balance is insufficient.").
+  revertPatterns:
+    - 'wallet balance is insufficient'
 
 terminator:
   backoffLimit: 3

--- a/infra/consumer_chart/app/settings.yaml
+++ b/infra/consumer_chart/app/settings.yaml
@@ -47,6 +47,11 @@ buyer:
     # parked for recovery). Match the real wording; keep the old one too.
     - 'duplicated passport'
     - 'duplicate passport'
+  # KTMB error substrings that mean a transient, ticket-less buy failure — the
+  # buyer reverts these bookings Buying -> Pending to retry (e.g. the KTMB
+  # e-wallet ran out of funds at Pay: "KTM Wallet balance is insufficient.").
+  revertPatterns:
+    - 'wallet balance is insufficient'
 
 terminator:
   backoffLimit: 3

--- a/lib/buyer/buyer.go
+++ b/lib/buyer/buyer.go
@@ -13,15 +13,17 @@ type Buyer struct {
 	logger           *zerolog.Logger
 	sleepBuffer      int
 	conflictPatterns []string
+	revertPatterns   []string
 }
 
-func NewBuyer(k ktmb.Ktmb, logger *zerolog.Logger, contactNumber string, sleepBuffer int, conflictPatterns []string) Buyer {
+func NewBuyer(k ktmb.Ktmb, logger *zerolog.Logger, contactNumber string, sleepBuffer int, conflictPatterns, revertPatterns []string) Buyer {
 	return Buyer{
 		ktmb:             k,
 		logger:           logger,
 		contactNumber:    contactNumber,
 		sleepBuffer:      sleepBuffer,
 		conflictPatterns: conflictPatterns,
+		revertPatterns:   revertPatterns,
 	}
 }
 
@@ -105,6 +107,11 @@ func (c *Buyer) Buy(userData, bookingData string, p Passenger, direction, date, 
 		return nil, "", "", err
 	}
 	if !pay.Status {
+		if matchesConflict(c.revertPatterns, pay.Messages) {
+			e := &RevertError{Messages: pay.Messages}
+			c.logger.Warn().Err(e).Strs("errors", pay.Messages).Str("date", date).Str("time", t).Str("dir", direction).Msg("Transient pay failure with no ticket bought (revertable)")
+			return nil, "", "", e
+		}
 		e := fmt.Errorf("failed to pay: %+v", pay.Messages)
 		c.logger.Error().Err(e).Strs("errors", pay.Messages).Msg("Failed to pay")
 		return nil, "", "", e

--- a/lib/buyer/client.go
+++ b/lib/buyer/client.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"math"
 	"mime/multipart"
+	"net/http"
 	"time"
 )
 
@@ -235,7 +236,14 @@ func (c *Client) buy(ctx context.Context, direction, date, t, userData, bookingD
 	if err != nil {
 		var conflictErr *ConflictError
 		var purchasedErr *PurchasedError
+		var revertErr *RevertError
 		switch {
+		case errors.As(err, &revertErr):
+			// transient failure that captured NO ticket (e.g. KTMB wallet out) —
+			// revert the booking Buying -> Pending so the pipeline retries it,
+			// and release the KTMB reservation. Safe: no ticket exists.
+			c.logger.Warn().Ctx(ctx).Err(err).Str("date", date).Str("time", t).Str("dir", direction).Msg("Transient buy failure, reverting booking to Pending")
+			return c.revert(ctx, data.Id, userData, bookingData)
 		case errors.As(err, &conflictErr):
 			// this passenger already holds a ticket for this slot — park the
 			// booking for the recoverer and free the KTMB reservation
@@ -296,6 +304,33 @@ func (c *Client) completeOnce(ctx context.Context, id openapi_types.UUID, bookin
 		body, _ := io.ReadAll(completed.Body)
 		return fmt.Errorf("failed to mark booking as complete: status %d: %s", completed.StatusCode, string(body))
 	}
+	return nil
+}
+
+// revert recycles a booking that failed for a transient, ticket-less reason
+// (e.g. KTMB wallet insufficient): it moves the booking Buying -> Pending in
+// zinc so the pipeline re-reserves and retries it once the condition clears,
+// and releases the KTMB reservation. zinc's Revert is guarded (Buying-only +
+// uncaptured) so this can never re-buy a booking that already holds a ticket.
+// On a revert failure the booking simply stays Buying for the manual revert
+// path — no ticket is ever at risk here (Pay failed, nothing was bought).
+func (c *Client) revert(ctx context.Context, id openapi_types.UUID, userData, bookingData string) error {
+	resp, err := c.zinc.PostApiVVersionBookingRevertId(ctx, "1.0", id)
+	if err != nil {
+		c.logger.Error().Ctx(ctx).Err(err).Msg("Failed to revert booking to Pending")
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		c.logger.Error().Ctx(ctx).Int("status", resp.StatusCode).Str("body", string(body)).Msg("Failed to revert booking to Pending")
+		return fmt.Errorf("failed to revert booking: status %d", resp.StatusCode)
+	}
+	if _, e := c.buyer.Release(userData, bookingData); e != nil {
+		// best effort: the reservation will otherwise expire on its own
+		c.logger.Error().Ctx(ctx).Err(e).Msg("Failed to release KTMB reservation after revert")
+	}
+	c.logger.Info().Ctx(ctx).Msg("Booking reverted to Pending for retry")
 	return nil
 }
 

--- a/lib/buyer/errors.go
+++ b/lib/buyer/errors.go
@@ -17,6 +17,18 @@ func (e *ConflictError) Error() string {
 	return fmt.Sprintf("ktmb conflict (duplicate passenger): %+v", e.Messages)
 }
 
+// RevertError marks a KTMB buy that failed for a transient reason that captured
+// NO ticket (e.g. "wallet balance is insufficient" at Pay). The booking should
+// be reverted Buying -> Pending to retry once the condition clears, rather than
+// stranded in Buying.
+type RevertError struct {
+	Messages []string
+}
+
+func (e *RevertError) Error() string {
+	return fmt.Sprintf("ktmb transient failure (revert to pending): %+v", e.Messages)
+}
+
 // PurchasedError marks a purchase that SUCCEEDED on KTMB (payment captured,
 // booking confirmed) but whose ticket artifacts could not be retrieved. The
 // ticket exists — callers must never treat this as a failed buy or release

--- a/lib/buyer/errors_test.go
+++ b/lib/buyer/errors_test.go
@@ -52,3 +52,20 @@ func TestMatchesConflictEmptyPatterns(t *testing.T) {
 		t.Error("empty pattern must never match")
 	}
 }
+
+// The buyer reverts a booking Buying -> Pending when Pay fails with a transient,
+// ticket-less error. KTMB's real message is "KTM Wallet balance is insufficient.";
+// the configured revertPatterns must match it (case-insensitive substring) but
+// NOT an unrelated failure like a duplicate-passport conflict.
+func TestRevertPatternMatchesWalletInsufficient(t *testing.T) {
+	patterns := []string{"wallet balance is insufficient"}
+	if !matchesConflict(patterns, []string{"KTM Wallet balance is insufficient."}) {
+		t.Fatal("revert pattern must match KTMB's wallet-insufficient message")
+	}
+	if matchesConflict(patterns, []string{"Duplicated passport number for onward trip : K4461909G."}) {
+		t.Fatal("revert pattern must not match a duplicate-passport error")
+	}
+	if matchesConflict(patterns, []string{"Not enough seat for onward trip."}) {
+		t.Fatal("revert pattern must not match an out-of-seats error")
+	}
+}

--- a/lib/zinc/main.go
+++ b/lib/zinc/main.go
@@ -748,6 +748,12 @@ type ClientInterface interface {
 	// PostApiVVersionBookingBuyingId request
 	PostApiVVersionBookingBuyingId(ctx context.Context, version string, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// PostApiVVersionBookingRevertId request
+	// NOTE: manually added (mirrors the generated Buying method) for the zinc 1.36
+	// revert endpoint; only the raw method is provided, no WithResponse variant.
+	// Regenerate via `pls sdk:gen` against zinc >= 1.36 to reconcile this file.
+	PostApiVVersionBookingRevertId(ctx context.Context, version string, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// PostApiVVersionBookingCancelId request
 	PostApiVVersionBookingCancelId(ctx context.Context, version string, id openapi_types.UUID, params *PostApiVVersionBookingCancelIdParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -1076,6 +1082,18 @@ func (c *Client) GetApiVVersionBooking(ctx context.Context, version string, para
 
 func (c *Client) PostApiVVersionBookingBuyingId(ctx context.Context, version string, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPostApiVVersionBookingBuyingIdRequest(c.Server, version, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostApiVVersionBookingRevertId(ctx context.Context, version string, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostApiVVersionBookingRevertIdRequest(c.Server, version, id)
 	if err != nil {
 		return nil, err
 	}
@@ -2451,6 +2469,47 @@ func NewPostApiVVersionBookingBuyingIdRequest(server string, version string, id 
 	}
 
 	operationPath := fmt.Sprintf("/api/v%s/Booking/buying/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPostApiVVersionBookingRevertIdRequest generates requests for PostApiVVersionBookingRevertId
+func NewPostApiVVersionBookingRevertIdRequest(server string, version string, id openapi_types.UUID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "version", runtime.ParamLocationPath, version)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v%s/Booking/revert/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}

--- a/system/config/model.go
+++ b/system/config/model.go
@@ -62,6 +62,12 @@ type BuyerConfig struct {
 	// ConflictPatterns are case-insensitive substrings of KTMB SetPassenger
 	// error messages that mean "this passenger already holds a ticket"
 	ConflictPatterns []string
+	// RevertPatterns are case-insensitive substrings of KTMB error messages that
+	// mean the buy failed for a transient reason that captured NO ticket (e.g.
+	// "wallet balance is insufficient" at Pay). The buyer reverts these bookings
+	// Buying -> Pending so the pipeline retries them once the condition clears,
+	// instead of stranding them in Buying.
+	RevertPatterns []string
 }
 
 // Terminator Config


### PR DESCRIPTION
When KTMB Pay fails with **"wallet balance is insufficient"** the buy captured no ticket, but the buyer left the booking stuck in `Buying` (generic-failure path) — and nothing recycles it (recoverer only handles `Recovering`; reserver only re-reserves `Pending`). This is the actual cause of the current stuck-`Buying` pile-up (24× "KTM Wallet balance is insufficient" in prod).

## Change
The buyer now classifies Pay failures against a configurable `revertPatterns` (default `"wallet balance is insufficient"`) into a typed `RevertError`, and calls zinc's new atomic **`Revert`** endpoint to move the booking `Buying → Pending` + release the KTMB reservation. It re-enters the demand pool and retries once the wallet is topped up.

**Safe:** only fires when Pay failed (no ticket exists), and zinc's `Revert` is itself guarded (`Buying`-only + uncaptured). Transport errors at Pay (ambiguous) take the default path and stay in `Buying`, never revert.

- `lib/zinc`: hand-add `PostApiVVersionBookingRevertId` (matches deployed zinc 1.36; mirrors the generated Buying method; marked for regen).
- config: `BuyerConfig.RevertPatterns` in both settings copies.
- test: revert pattern matches the real KTMB wallet message, not duplicate-passport / out-of-seats.

## Depends on
zinc **1.36.0** (atomic `Revert` endpoint) — already deployed to raichu.

## Verification
Docker build + vet + buyer tests pass. floop 1 round, all lenses PASS.

**Note:** the real-world blocker is the **empty KTMB wallet** — this makes stuck bookings *recyclable* so they succeed once it's topped up.

https://claude.ai/code/session_01Xyb9Y7aiWqGwGbtXRAL3ES