### PR TITLE
feat(recoverer): mark Duplicate when ticket not on our KTMB account

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,9 +107,10 @@ PrintTicket`, and reports the completed ticket back to `zinc`. Releases on a 404
   hourly (`robfig/cron`) and reconciles zinc's `Recovering` bookings. Resolves
   duplicate-passport conflicts and captured-but-unreported tickets: force-completes when the
   ticket exists uncaptured on our KTMB account (binary-search of `UpcomingShuttleList`), marks
-  the booking `Duplicate` (full refund) when the passenger holds it via another channel, re-buys
-  when the conflict was transient, or parks it as `RequireManualIntervention` when it cannot
-  decide safely. The buyer feeds it by parking conflicted bookings instead of crash-looping.
+  the booking `Duplicate` (full refund) when the ticket is not on our account (the passenger
+  holds it via another channel), or parks it as `RequireManualIntervention` when it cannot
+  decide safely. It never re-buys. The buyer feeds it by parking conflicted bookings instead of
+  crash-looping.
 
 Operational / utility subcommands:
 

--- a/cmds/recoverer.go
+++ b/cmds/recoverer.go
@@ -11,13 +11,10 @@ import (
 	"strings"
 
 	"github.com/AtomiCloud/nitroso-tin/lib"
-	"github.com/AtomiCloud/nitroso-tin/lib/buyer"
 	"github.com/AtomiCloud/nitroso-tin/lib/encryptor"
-	"github.com/AtomiCloud/nitroso-tin/lib/enricher"
 	"github.com/AtomiCloud/nitroso-tin/lib/ktmb"
 	"github.com/AtomiCloud/nitroso-tin/lib/otelredis"
 	"github.com/AtomiCloud/nitroso-tin/lib/recoverer"
-	"github.com/AtomiCloud/nitroso-tin/lib/reserver"
 	"github.com/AtomiCloud/nitroso-tin/lib/session"
 	"github.com/AtomiCloud/nitroso-tin/lib/zinc"
 	"github.com/google/uuid"
@@ -42,16 +39,12 @@ func (state *State) buildRecoverer() (*recoverer.Client, *zinc.Client, error) {
 	}
 
 	loginEncr := encryptor.NewSymEncryptor[ktmb.LoginRes](state.Config.Encryptor.Key, state.Logger)
-	findEncr := encryptor.NewSymEncryptor[enricher.FindStore](state.Config.Encryptor.Key, state.Logger)
 	recoverEncr := encryptor.NewSymEncryptor[lib.RecoverDto](state.Config.Encryptor.Key, state.Logger)
 
 	s := session.New(&k, &mainRedis, state.Logger, state.Config.Ktmb.LoginKey, loginEncr)
-	retriever := reserver.NewRetriever(&mainRedis, findEncr, state.Logger, state.Config.Enricher)
 
-	b := buyer.NewBuyer(k, state.Logger, buyerCfg.ContactNumber, buyerCfg.SleepBuffer, buyerCfg.ConflictPatterns, buyerCfg.RevertPatterns)
-
-	client := recoverer.New(k, &b, &s, retriever, &mainRedis, zClient, recoverEncr, state.OtelConfigurator,
-		state.Logger, state.Config.Recoverer, state.Config.Enricher, state.Psm, ktmbAppInfo, state.Location)
+	client := recoverer.New(k, &s, &mainRedis, zClient, recoverEncr, state.OtelConfigurator,
+		state.Logger, state.Config.Recoverer, state.Config.Enricher, state.Psm, state.Location)
 	return client, zClient, nil
 }
 

--- a/docs/RECOVERY.md
+++ b/docs/RECOVERY.md
@@ -71,9 +71,9 @@ Recovering=6, Duplicate=7, RequireManualIntervention=8`. Stored as smallint; str
    **conclusive** scan of our KTMB account that did not find our ticket, or when the found
    ticket is already claimed by a different `Completed` zinc booking. An _inconclusive_ scan
    (empty/blank list, mutated pagination) must retry, never refund.
-4. **No double buy.** A re-buy that succeeds stashes its ticket identifiers so a later
-   complete-failure force-completes deterministically instead of re-buying. A re-buy that
-   conflicts spends no money (KTMB rejects pre-payment; the reservation is released).
+4. **No re-buy.** The recoverer never re-purchases a ticket. A booking whose ticket is not on
+   our KTMB account is refunded as `Duplicate`, not bought again — so recovery can never spend
+   money or create a second KTMB booking for the same passenger.
 5. **No stranded money.** A booking with money held in `BookingReserve` is never left in a
    state no path can resolve: `Recovering` is reconciled every cycle; `Buying` is covered by
    the queue item and the manual `recover` command; `RequireManualIntervention` is resolved by
@@ -122,11 +122,11 @@ sweep drains first). Per booking (`ProcessItem`):
    - found + unclaimed → force complete;
    - found + claimed by another `Completed` booking → `duplicate` (refund);
    - inconclusive (empty in-range page, mutated list) → **retry** (never refund);
-   - not found → **re-buy probe** (reserve + buy):
-     - success → complete (stash identifiers first);
-     - `ConflictError` → release probe, **strict re-scan** (empty list = inconclusive → retry);
-       found → force complete; conclusively not ours → `duplicate` (another channel);
-     - `PurchasedError` → requeue deterministically with identifiers.
+   - **not found → `duplicate` (refund).** A conclusive absence means the passenger holds this
+     seat via another channel (KTMB rejected our purchase as a duplicate passport, and the
+     ticket is not on our account). The recoverer does **not** attempt a re-buy — only a
+     _definitive_ not-found reaches here (an inconclusive scan errored out above and retries),
+     so this can never refund a booking whose ticket we actually hold.
 7. Item fails `maxAttempts` cycles → `manual-intervention`.
 
 ### Durability model (queue + sweep)

--- a/lib/recoverer/client.go
+++ b/lib/recoverer/client.go
@@ -6,11 +6,9 @@ import (
 	"time"
 
 	"github.com/AtomiCloud/nitroso-tin/lib"
-	"github.com/AtomiCloud/nitroso-tin/lib/buyer"
 	"github.com/AtomiCloud/nitroso-tin/lib/encryptor"
 	"github.com/AtomiCloud/nitroso-tin/lib/ktmb"
 	"github.com/AtomiCloud/nitroso-tin/lib/otelredis"
-	"github.com/AtomiCloud/nitroso-tin/lib/reserver"
 	"github.com/AtomiCloud/nitroso-tin/lib/session"
 	"github.com/AtomiCloud/nitroso-tin/lib/zinc"
 	"github.com/AtomiCloud/nitroso-tin/system/config"
@@ -22,8 +20,8 @@ import (
 
 // Client drains the recover queue on a cron and resolves each parked booking:
 // force-complete when the ticket is provably ours, mark duplicate when the
-// passenger already holds it elsewhere, re-buy when no conflict actually
-// exists, and park for a human when nothing can be decided safely.
+// ticket is not on our KTMB account (the passenger holds it elsewhere), and
+// park for a human when nothing can be decided safely.
 //
 // SINGLE REPLICA ONLY. The drain pops with a destructive RPop and the sweep's
 // queued-skip / handled-skip dedup assumes the drain and sweep run sequentially
@@ -33,9 +31,7 @@ import (
 // values); do not add an HPA.
 type Client struct {
 	ktmb             ktmb.Ktmb
-	buyer            *buyer.Buyer
 	session          *session.Session
-	retriever        *reserver.Retriever
 	mainRedis        *otelredis.OtelRedis
 	zinc             *zinc.Client
 	encr             encryptor.Encryptor[lib.RecoverDto]
@@ -44,19 +40,16 @@ type Client struct {
 	config           config.RecovererConfig
 	enricher         config.EnricherConfig
 	psm              string
-	appInfo          string
 	loc              *time.Location
 }
 
-func New(k ktmb.Ktmb, b *buyer.Buyer, s *session.Session, retriever *reserver.Retriever, mainRedis *otelredis.OtelRedis,
+func New(k ktmb.Ktmb, s *session.Session, mainRedis *otelredis.OtelRedis,
 	zClient *zinc.Client, encr encryptor.Encryptor[lib.RecoverDto], otelConfigurator *telemetry.OtelConfigurator,
-	logger *zerolog.Logger, cfg config.RecovererConfig, enricher config.EnricherConfig, psm, appInfo string,
+	logger *zerolog.Logger, cfg config.RecovererConfig, enricher config.EnricherConfig, psm string,
 	loc *time.Location) *Client {
 	return &Client{
 		ktmb:             k,
-		buyer:            b,
 		session:          s,
-		retriever:        retriever,
 		mainRedis:        mainRedis,
 		zinc:             zClient,
 		encr:             encr,
@@ -65,7 +58,6 @@ func New(k ktmb.Ktmb, b *buyer.Buyer, s *session.Session, retriever *reserver.Re
 		config:           cfg,
 		enricher:         enricher,
 		psm:              psm,
-		appInfo:          appInfo,
 		loc:              loc,
 	}
 }

--- a/lib/recoverer/process.go
+++ b/lib/recoverer/process.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,7 +14,6 @@ import (
 	"github.com/AtomiCloud/nitroso-tin/lib/buyer"
 	"github.com/AtomiCloud/nitroso-tin/lib/zinc"
 	"github.com/google/uuid"
-	"github.com/rs/zerolog"
 )
 
 const zincDateTimeLayout = "02-01-2006 15:04:05"
@@ -108,7 +106,7 @@ func (c *Client) ProcessItem(ctx context.Context, dto lib.RecoverDto) error {
 	found, err := c.findTicket(userData, target, dto.Direction, dto.PassportNumber)
 	if err != nil {
 		// an inconclusive scan (empty/blank list, mutated pagination, unparseable
-		// row) must never fall through to a refund OR a re-buy probe
+		// row) must never fall through to a refund — only a definitive not-found does
 		l.Error().Err(err).Msg("KTMB ticket scan inconclusive, will retry")
 		return err
 	}
@@ -129,132 +127,14 @@ func (c *Client) ProcessItem(ctx context.Context, dto lib.RecoverDto) error {
 		return c.forceComplete(ctx, dto.BookingId, found.BookingNo, found.TicketNo)
 	}
 
-	// not on our account: either the user bought via another channel, or the
-	// conflict was transient. A re-buy attempt distinguishes them — KTMB
-	// rejects with the same duplicate error if the passenger is booked anywhere
-	l.Info().Msg("Ticket not on our KTMB account, probing with a re-buy")
-	return c.rebuy(ctx, dto, userData, target, l)
-}
-
-func (c *Client) rebuy(ctx context.Context, dto lib.RecoverDto, userData string, target time.Time, l zerolog.Logger) error {
-	store, err := c.retriever.GetLoginData(ctx)
-	if err != nil {
-		return err
-	}
-	if store == nil {
-		return fmt.Errorf("no login/find store available for re-buy")
-	}
-
-	find := store.Find[dto.Direction][dto.Date][dto.Time]
-	if find.TripData == "" {
-		return fmt.Errorf("no trip data available for %s %s %s", dto.Direction, dto.Date, dto.Time)
-	}
-
-	reserve, err := c.ktmb.Reserve(store.UserData, c.appInfo, find.SearchData, find.TripData)
-	if err != nil {
-		return err
-	}
-	if !reserve.Status {
-		return fmt.Errorf("failed to reserve for re-buy: %+v", reserve.Messages)
-	}
-	bookingData := reserve.Data.BookingData
-
-	p := buyer.Passenger{
-		FullName:       dto.FullName,
-		Gender:         dto.Gender,
-		PassportExpiry: dto.PassportExpiry,
-		PassportNumber: dto.PassportNumber,
-	}
-
-	pdf, bookingNo, ticketNo, err := c.buyer.Buy(store.UserData, bookingData, p, dto.Direction, dto.Date, dto.Time)
-	if err != nil {
-		var conflictErr *buyer.ConflictError
-		var purchasedErr *buyer.PurchasedError
-		switch {
-		case errors.As(err, &conflictErr):
-			// the probe confirms the passenger is booked somewhere. Release the
-			// probe reservation, then re-scan to decide WHOSE ticket it is —
-			// never refund on a contradictory/inconclusive scan.
-			if _, e := c.buyer.Release(store.UserData, bookingData); e != nil {
-				l.Error().Err(e).Msg("Failed to release probe reservation")
-			}
-			return c.resolveConflict(ctx, dto, func() (*foundTicket, error) {
-				// KTMB just told us the passenger is booked, so an empty own-account
-				// list is contradictory; findTicket treats it (and every other
-				// inconclusive condition) as an error that must not drive a refund
-				return c.findTicket(userData, target, dto.Direction, dto.PassportNumber)
-			}, l)
-		case errors.As(err, &purchasedErr):
-			// bought but ticket retrieval failed — requeue deterministically
-			l.Warn().Err(err).Msg("Re-buy purchased but ticket retrieval failed, requeueing with ticket identifiers")
-			dto.BookingNo = purchasedErr.BookingNo
-			dto.TicketNo = purchasedErr.TicketNo
-			c.requeue(ctx, dto)
-			return nil
-		default:
-			if _, e := c.buyer.Release(store.UserData, bookingData); e != nil {
-				l.Error().Err(e).Msg("Failed to release probe reservation")
-			}
-			return err
-		}
-	}
-
-	// Buy succeeded — real money spent. Stash the identifiers so recovery is
-	// deterministic even if the complete call fails now (never re-buy).
-	dto.BookingNo = bookingNo
-	dto.TicketNo = ticketNo
-	l.Info().Str("bookingNo", bookingNo).Str("ticketNo", ticketNo).Msg("Re-buy succeeded, completing booking")
-	if err := c.completeBooking(ctx, dto.BookingId, bookingNo, ticketNo, pdf); err != nil {
-		l.Error().Err(err).Msg("Re-buy succeeded but complete failed, requeueing with ticket identifiers")
-		c.requeue(ctx, dto)
-		return nil
-	}
-	return nil
-}
-
-// resolveConflict decides a booking whose re-buy probe was rejected as a
-// duplicate: re-scan our KTMB account to find WHOSE ticket blocks it. It
-// applies the same gates as the main scan's found-path (§5.6) — in particular
-// the claim gate: a found ticket already recorded on another Completed zinc
-// booking marks THIS booking Duplicate (refund), because force-completing it
-// would collect this booking's reserve for a ticket someone else owns. Only a
-// conclusive "not on our account" re-scan may refund; an inconclusive re-scan
-// (or claim check) retries.
-func (c *Client) resolveConflict(ctx context.Context, dto lib.RecoverDto, rescan func() (*foundTicket, error), l zerolog.Logger) error {
-	found, err := rescan()
-	if err != nil {
-		l.Error().Err(err).Msg("Re-buy conflicted but re-scan inconclusive, will retry")
-		return err
-	}
-	if found == nil {
-		l.Warn().Msg("Re-buy confirmed conflict and ticket is not on our account, marking duplicate")
-		return c.markDuplicate(ctx, dto.BookingId)
-	}
-	claimed, err := c.isClaimed(ctx, dto, found.BookingNo)
-	if err != nil {
-		// retry with the ORIGINAL dto (no stashed identifiers): stashing before
-		// the claim gate passes would route the next cycle onto the deterministic
-		// force-complete path, which skips this gate entirely
-		l.Error().Err(err).Str("ktmbBookingNo", found.BookingNo).Msg("Re-scan found a ticket but the claim check failed, will retry")
-		return err
-	}
-	if claimed {
-		// the ticket on our account already belongs to another zinc booking
-		// (user double-booked) — this booking is a true duplicate
-		l.Warn().Str("ktmbBookingNo", found.BookingNo).Msg("Re-scan ticket already claimed by another completed booking, marking duplicate")
-		return c.markDuplicate(ctx, dto.BookingId)
-	}
-	// ours and unclaimed: stash identifiers so a force-complete failure requeues
-	// onto the deterministic path next cycle instead of re-probing
-	dto.BookingNo = found.BookingNo
-	dto.TicketNo = found.TicketNo
-	l.Info().Str("ktmbBookingNo", found.BookingNo).Msg("Re-scan located our uncaptured ticket, force completing")
-	if e := c.forceComplete(ctx, dto.BookingId, found.BookingNo, found.TicketNo); e != nil {
-		l.Error().Err(e).Msg("Force complete failed after re-scan, requeueing with ticket identifiers")
-		c.requeue(ctx, dto)
-		return nil
-	}
-	return nil
+	// not on our account: the passenger holds this seat via another channel
+	// (KTMB rejected our purchase as a duplicate passport, and a definitive scan
+	// shows the ticket is not ours) — a true duplicate. Refund it. Only a
+	// DEFINITIVE absence reaches here: an inconclusive scan (empty/mutated list,
+	// unparseable row) returned an error above and is retried, never refunded, so
+	// this can never refund a booking whose ticket we actually hold.
+	l.Warn().Msg("Ticket not on our KTMB account, marking duplicate")
+	return c.markDuplicate(ctx, dto.BookingId)
 }
 
 // forceComplete downloads the ticket PDF from KTMB and reports it to zinc

--- a/lib/recoverer/process_test.go
+++ b/lib/recoverer/process_test.go
@@ -3,7 +3,6 @@ package recoverer
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -16,9 +15,9 @@ import (
 
 const testBookingId = "b7f9c1de-4a2b-4c3d-9e8f-0a1b2c3d4e5f"
 
-// zincStub fakes the zinc endpoints resolveConflict may touch and records
-// every status transition it drives, so tests can assert exactly which
-// resolution (duplicate vs force-complete) was chosen.
+// zincStub fakes the zinc endpoints the recoverer touches and records every
+// status transition it drives, so tests can assert exactly which resolution
+// (duplicate vs force-complete) was chosen.
 type zincStub struct {
 	t            *testing.T
 	searchStatus int // 0 → 200
@@ -72,93 +71,32 @@ func recoverDto() lib.RecoverDto {
 	}
 }
 
-// The §5.6 double-charge guard: booking A is Completed holding KTMB ticket K1;
-// booking B (same passenger/slot) is Recovering. B's re-buy probe conflicts and
-// the re-scan finds K1 — because K1 is already claimed by A, B must be marked
-// Duplicate (refund), NEVER force-completed (that would collect B's reserve for
-// a ticket A owns). This is the same claim gate the main scan path applies.
-func TestResolveConflictClaimedTicketMarksDuplicate(t *testing.T) {
+// isClaimed is the money-critical §5.6 double-charge gate on the found-ticket
+// path: a KTMB ticket already recorded on another Completed zinc booking must
+// mark THIS booking Duplicate (refund), never force-complete (which would
+// collect this booking's reserve for a ticket someone else owns). These tests
+// pin the gate decision directly.
+
+// The gate returns true when our uncaptured KTMB booking number already appears
+// on a Completed zinc booking for the same passenger+slot.
+func TestIsClaimedMatchingBookingNoIsClaimed(t *testing.T) {
 	no := "KTMB-K1"
 	stub := &zincStub{t: t, searchBody: []zinc.BookingPrincipalRes{{BookingNo: &no}}}
 	c, closeSrv := conflictClient(t, stub)
 	defer closeSrv()
 
-	rescan := func() (*foundTicket, error) {
-		return &foundTicket{BookingNo: "KTMB-K1", TicketNo: "T1"}, nil
-	}
-	if err := c.resolveConflict(context.Background(), recoverDto(), rescan, zerolog.Nop()); err != nil {
+	claimed, err := c.isClaimed(context.Background(), recoverDto(), "KTMB-K1")
+	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
-	if len(stub.duplicated) != 1 || stub.duplicated[0] != testBookingId {
-		t.Errorf("expected duplicate transition for %s, got %v", testBookingId, stub.duplicated)
-	}
-	if len(stub.completed) != 0 {
-		t.Errorf("claimed ticket must never be force-completed, got complete calls %v", stub.completed)
+	if !claimed {
+		t.Error("a ticket whose booking number matches a Completed booking must be considered claimed")
 	}
 }
 
-// A failed claim check is inconclusive: retry (error return), never refund and
-// never capture. The error path must not stash the found identifiers — a
-// stashed id would route the next cycle onto the deterministic force-complete
-// path, which skips the claim gate.
-func TestResolveConflictClaimCheckFailureRetries(t *testing.T) {
-	stub := &zincStub{t: t, searchStatus: http.StatusBadGateway}
-	c, closeSrv := conflictClient(t, stub)
-	defer closeSrv()
-
-	rescan := func() (*foundTicket, error) {
-		return &foundTicket{BookingNo: "KTMB-K1", TicketNo: "T1"}, nil
-	}
-	if err := c.resolveConflict(context.Background(), recoverDto(), rescan, zerolog.Nop()); err == nil {
-		t.Fatal("expected error when the claim check fails, got nil")
-	}
-	if len(stub.duplicated) != 0 || len(stub.completed) != 0 {
-		t.Errorf("no transition may run on a failed claim check, got duplicate %v complete %v", stub.duplicated, stub.completed)
-	}
-}
-
-// An inconclusive re-scan (empty list, mutated pagination, unparseable row)
-// must retry — never read as "not ours" and refund (§3.3/§5.6).
-func TestResolveConflictInconclusiveRescanRetries(t *testing.T) {
-	stub := &zincStub{t: t}
-	c, closeSrv := conflictClient(t, stub)
-	defer closeSrv()
-
-	rescan := func() (*foundTicket, error) {
-		return nil, fmt.Errorf("empty ticket list (inconclusive, must retry — never treat as absent)")
-	}
-	if err := c.resolveConflict(context.Background(), recoverDto(), rescan, zerolog.Nop()); err == nil {
-		t.Fatal("expected error for inconclusive re-scan, got nil")
-	}
-	if len(stub.duplicated) != 0 || len(stub.completed) != 0 {
-		t.Errorf("no transition may run on an inconclusive re-scan, got duplicate %v complete %v", stub.duplicated, stub.completed)
-	}
-}
-
-// KTMB confirmed the conflict and a conclusive re-scan shows the ticket is not
-// on our account: the passenger holds it via another channel — true duplicate.
-func TestResolveConflictNotOnAccountMarksDuplicate(t *testing.T) {
-	stub := &zincStub{t: t}
-	c, closeSrv := conflictClient(t, stub)
-	defer closeSrv()
-
-	rescan := func() (*foundTicket, error) { return nil, nil }
-	if err := c.resolveConflict(context.Background(), recoverDto(), rescan, zerolog.Nop()); err != nil {
-		t.Fatalf("expected nil error, got %v", err)
-	}
-	if len(stub.duplicated) != 1 || stub.duplicated[0] != testBookingId {
-		t.Errorf("expected duplicate transition for %s, got %v", testBookingId, stub.duplicated)
-	}
-	if len(stub.completed) != 0 {
-		t.Errorf("expected no complete calls, got %v", stub.completed)
-	}
-}
-
-// A found ticket claimed by a DIFFERENT KTMB booking number than any Completed
-// zinc booking is unclaimed: the claim gate must let it through to capture.
-// (The capture itself needs a live KTMB session, so this only asserts the gate
-// decision — isClaimed — not the force-complete plumbing.)
-func TestResolveConflictUnclaimedIsNotDuplicate(t *testing.T) {
+// A found ticket whose KTMB booking number matches no Completed zinc booking is
+// unclaimed: the gate must let it through to capture (force-complete).
+func TestIsClaimedUnmatchedBookingNoIsNotClaimed(t *testing.T) {
 	other := "KTMB-OTHER"
 	stub := &zincStub{t: t, searchBody: []zinc.BookingPrincipalRes{{BookingNo: &other}}}
 	c, closeSrv := conflictClient(t, stub)
@@ -171,7 +109,17 @@ func TestResolveConflictUnclaimedIsNotDuplicate(t *testing.T) {
 	if claimed {
 		t.Error("ticket with an unmatched booking number must not be considered claimed")
 	}
-	if len(stub.duplicated) != 0 || len(stub.completed) != 0 {
-		t.Errorf("expected no transitions, got duplicate %v complete %v", stub.duplicated, stub.completed)
+}
+
+// A failed claim search is inconclusive: it must surface an error (caller
+// retries), never a silent "not claimed" that would force-complete a ticket
+// another booking may own.
+func TestIsClaimedSearchFailureErrors(t *testing.T) {
+	stub := &zincStub{t: t, searchStatus: http.StatusBadGateway}
+	c, closeSrv := conflictClient(t, stub)
+	defer closeSrv()
+
+	if _, err := c.isClaimed(context.Background(), recoverDto(), "KTMB-K1"); err == nil {
+		t.Fatal("expected error when the claim search fails, got nil")
 	}
 }

--- a/lib/recoverer/scan_test.go
+++ b/lib/recoverer/scan_test.go
@@ -132,8 +132,8 @@ func TestMatchPage(t *testing.T) {
 // (abbreviated/localized/blank) is misclassified by directionOf as "JToW". Such
 // a row, carrying OUR passport at the target datetime, must surface as
 // inconclusive (retry), never be silently skipped — a silent skip reads as "not
-// ours" and, via the re-buy conflict path, drives a wrongful refund of a ticket
-// we actually hold (§3.3).
+// ours", which now drives a wrongful refund of a ticket we actually hold
+// directly (not found → Duplicate) (§3.3).
 func TestMatchPageDirectionUnconfirmedIsInconclusive(t *testing.T) {
 	loc := sgLoc(t)
 	target := time.Date(2026, 7, 3, 13, 45, 0, 0, loc)
@@ -340,8 +340,7 @@ func TestFindTicketInMalformedMatchingRow(t *testing.T) {
 	target := time.Date(2026, 7, 3, 13, 45, 0, 0, loc)
 	// single page; the row that WOULD match the target passport has a malformed
 	// departure. The scan must be inconclusive (retry), never "not found" —
-	// "not found" leads to a re-buy probe and, after a conflict + a re-scan
-	// that also skips the row, a wrongful refund.
+	// "not found" now leads directly to a Duplicate refund of a ticket we hold.
 	fetch := func(page int64) (ktmb.TicketListRes, error) {
 		return ktmb.TicketListRes{Page: 1, TotalPage: 1, Bookings: []ktmb.TicketListBookingRes{
 			ticket("2026-07-03T10:00:00", "WOODLANDS CIQ", "A", "A", "AA"),
@@ -401,8 +400,8 @@ func TestFindTicketInEmptyListInconclusive(t *testing.T) {
 		return ktmb.TicketListRes{Page: 1, TotalPage: 0, Bookings: nil}, nil
 	}
 	// an empty/blank list is ALWAYS inconclusive (spec §3.3/§5.6): it must
-	// retry, never read as "not on our account" — that would trigger a re-buy
-	// probe (and, post-conflict, could drive a refund of a held ticket)
+	// retry, never read as "not on our account" — that would drive a Duplicate
+	// refund of a held ticket
 	if _, err := findTicketIn(empty, target, "WToJ", "AA", loc); err == nil {
 		t.Error("empty list: expected inconclusive error, got nil")
 	}
@@ -415,7 +414,7 @@ func TestFindTicketInEmptyContiguousScanPage(t *testing.T) {
 	// datetime (so the page contains the target datetime but yields no match for
 	// our passport). page 2 — reachable only by the contiguous scan-right, never
 	// the bisection — comes back empty, though it could hold OUR ticket. The scan
-	// must report inconclusive, never a "not found" that would drive a re-buy /
+	// must report inconclusive, never a "not found" that would drive a Duplicate
 	// wrongful refund of a held ticket (spec §3.3).
 	fetch := func(page int64) (ktmb.TicketListRes, error) {
 		switch page {


### PR DESCRIPTION
## What

When the recoverer scans KTMB's `UpcomingShuttleList` and the passenger's ticket is **definitively not on our account**, mark the booking **`Duplicate` (full refund)** directly — instead of the previous re-buy probe.

## Why

The re-buy probe dead-ended at `RequireManualIntervention` whenever the train had **sold out** (no seat to probe with), stranding genuinely-duplicate bookings that should just be refunded. This was hit in production (passport `K5129398R`, 12-07-2026): a real duplicate that couldn't be re-bought → parked for manual intervention.

A definitive not-found means the passenger holds the seat via **another channel**, so a refund is the correct, money-safe resolution. Verified against live raichu KTMB for several real cases that the scanner's passport+datetime+direction match is correct.

## Money-safety

- **Only a DEFINITIVE not-found triggers the refund.** `findTicket` returns an *error* on every inconclusive condition (empty/mutated list, unparseable/ambiguous row), which still **retries** — so this can never refund a ticket we actually hold.
- The **found-path double-charge / claim gate is unchanged**: found+claimed → Duplicate, found+unclaimed → force-complete.
- `Duplicate` is terminal + guarded on the zinc side (refund once).
- The recoverer **never re-buys** now → recovery can never spend money or create a second KTMB booking.

## Changes

- `lib/recoverer/process.go`: not-found branch → `markDuplicate`; removed dead `rebuy` + `resolveConflict`.
- `lib/recoverer/client.go` + `cmds/recoverer.go`: dropped now-unused `buyer`/`retriever`/`appInfo` fields, constructor params, call site, imports.
- `lib/recoverer/process_test.go`: replaced the `resolveConflict` tests with direct `isClaimed` gate tests.
- Docs: `docs/RECOVERY.md`, `CLAUDE.md`.

Net: **+57 / −243** (mostly dead-code removal).

## Testing

- `go build ./...`, `go vet`, full `go test ./...` all green locally.
- Two independent review passes (money-safety + completeness) — money-safety PASS; completeness flagged only stale comments, now fixed.

https://claude.ai/code/session_01Xyb9Y7aiWqGwGbtXRAL3ES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recovering a ticket now goes straight to a duplicate refund when it’s definitively not on the account, instead of attempting an extra purchase.
  * Inconclusive scan results are handled more safely, reducing the chance of incorrect refunds or duplicate actions.
  * Conflict handling now parks problematic bookings for recovery instead of looping or crashing.

* **Documentation**
  * Updated recovery guidance to reflect the new “no re-buy” behavior and decision flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->