### PR TITLE
feat(withdrawer): 6-hourly reconcile sweep of Processing withdrawals

### DIFF
--- a/cmds/withdrawer.go
+++ b/cmds/withdrawer.go
@@ -25,8 +25,10 @@ func (state *State) buildWithdrawer() (*withdrawer.Client, error) {
 	return client, nil
 }
 
-// Withdrawer runs the nightly daemon that approves Pending withdrawals and
-// re-drives Processing withdrawals stuck without a payout confirmation
+// Withdrawer runs the cron daemon with two sweeps: a nightly approve sweep
+// that approves Pending withdrawals and re-drives Processing withdrawals
+// stuck without a payout confirmation, and a 6-hourly reconcile sweep that
+// asks zinc to reconcile every Processing withdrawal against Airwallex
 func (state *State) Withdrawer(c *cli.Context) error {
 	state.Logger.Info().Msg("Starting Withdrawer")
 

--- a/config/app/settings.yaml
+++ b/config/app/settings.yaml
@@ -67,6 +67,9 @@ withdrawer:
   # robfig/cron v1 spec with a leading seconds field, evaluated in UTC:
   # '0 0 0 * * *' = every day at 00:00:00 UTC
   cron: '0 0 0 * * *'
+  # reconcile sweep of Processing withdrawals against Airwallex:
+  # '0 0 */6 * * *' = every 6 hours at 00/06/12/18 UTC
+  reconcileCron: '0 0 */6 * * *'
   limit: 100
 
 app:

--- a/infra/consumer_chart/app/settings.yaml
+++ b/infra/consumer_chart/app/settings.yaml
@@ -67,6 +67,9 @@ withdrawer:
   # robfig/cron v1 spec with a leading seconds field, evaluated in UTC:
   # '0 0 0 * * *' = every day at 00:00:00 UTC
   cron: '0 0 0 * * *'
+  # reconcile sweep of Processing withdrawals against Airwallex:
+  # '0 0 */6 * * *' = every 6 hours at 00/06/12/18 UTC
+  reconcileCron: '0 0 */6 * * *'
   limit: 100
 
 app:

--- a/lib/withdrawer/client.go
+++ b/lib/withdrawer/client.go
@@ -19,10 +19,11 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// Client sweeps zinc nightly for Pending withdrawals and approves each one
-// (Pending -> Processing) via zinc's approve endpoint, one by one.
+// Client runs two cron sweeps against zinc:
 //
-// The sweep also RE-DRIVES stuck Processing withdrawals: zinc can leave a
+// The NIGHTLY APPROVE SWEEP (config.Cron) lists Pending withdrawals and
+// approves each one (Pending -> Processing) via zinc's approve endpoint, one
+// by one. It also RE-DRIVES stuck Processing withdrawals: zinc can leave a
 // withdrawal in Processing with no payout confirmation when an approve's
 // gateway call failed ambiguously or the pod died mid-flight. Re-approving
 // such a withdrawal is safe and expected — zinc re-drives the payout
@@ -31,7 +32,14 @@ import (
 // an InvalidWithdrawalOperation error, which the sweep treats as a benign
 // skip (see Sweep).
 //
-// SINGLE REPLICA ONLY. The sweep assumes it is the only approver: two
+// The 6-HOURLY RECONCILE SWEEP (config.ReconcileCron) lists Processing
+// withdrawals and POSTs each to zinc's reconcile endpoint, which looks the
+// transfer up at Airwallex and settles/fails/parks the withdrawal
+// server-side. A withdrawal no longer in Processing by the time the reconcile
+// lands is rejected by zinc with the same InvalidWithdrawalOperation error —
+// benign, someone else already resolved it (see Reconcile).
+//
+// SINGLE REPLICA ONLY. The sweeps assume they are the only approver: two
 // replicas would race to approve the same Pending withdrawal. zinc guards the
 // Pending -> Processing transition server-side (so a duplicate approve fails
 // rather than double-pays), but concurrent replicas would still produce noisy
@@ -67,37 +75,57 @@ func (c *Client) Start(ctx context.Context) error {
 		}
 	}()
 
-	ch := make(chan struct{}, 1)
+	approveCh := make(chan struct{}, 1)
+	reconcileCh := make(chan struct{}, 1)
 
-	// robfig/cron v1 evaluates specs in the runner's location; force UTC so the
-	// nightly sweep fires at 00:00 UTC regardless of the pod's timezone.
+	// robfig/cron v1 evaluates specs in the runner's location; force UTC so
+	// both sweeps fire on UTC wall time regardless of the pod's timezone.
 	cr := cron.NewWithLocation(time.UTC)
 	if err = cr.AddFunc(c.config.Cron, func() {
 		select {
-		case ch <- struct{}{}:
+		case approveCh <- struct{}{}:
 		default:
 		}
 	}); err != nil {
-		c.logger.Error().Ctx(ctx).Err(err).Str("cron", c.config.Cron).Msg("Failed to schedule withdrawer cron")
+		c.logger.Error().Ctx(ctx).Err(err).Str("cron", c.config.Cron).Msg("Failed to schedule withdrawer approve cron")
+		return err
+	}
+	if err = cr.AddFunc(c.config.ReconcileCron, func() {
+		select {
+		case reconcileCh <- struct{}{}:
+		default:
+		}
+	}); err != nil {
+		c.logger.Error().Ctx(ctx).Err(err).Str("cron", c.config.ReconcileCron).Msg("Failed to schedule withdrawer reconcile cron")
 		return err
 	}
 	cr.Start()
 	defer cr.Stop()
 
-	// nightly only: unlike the recoverer, do NOT sweep on startup — a redeploy
-	// must not approve withdrawals off-schedule. Just log readiness.
-	c.logger.Info().Ctx(ctx).Str("cron", c.config.Cron).Msg("Withdrawer scheduled, waiting for cron (UTC); no sweep on startup")
+	// cron only: unlike the recoverer, do NOT sweep on startup — a redeploy
+	// must not approve or reconcile withdrawals off-schedule. Just log which
+	// cron drives which sweep.
+	c.logger.Info().Ctx(ctx).
+		Str("approveCron", c.config.Cron).
+		Str("reconcileCron", c.config.ReconcileCron).
+		Msg("Withdrawer scheduled (UTC): approve sweep of Pending+Processing on approveCron, reconcile sweep of Processing on reconcileCron; no sweep on startup")
 
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-ch:
-			c.logger.Info().Ctx(ctx).Msg("Withdrawer sweep starting")
+		case <-approveCh:
+			c.logger.Info().Ctx(ctx).Msg("Withdrawer approve sweep starting")
 			if sweepErr := c.Sweep(ctx); sweepErr != nil {
-				c.logger.Error().Ctx(ctx).Err(sweepErr).Msg("Withdrawer sweep failed")
+				c.logger.Error().Ctx(ctx).Err(sweepErr).Msg("Withdrawer approve sweep failed")
 			}
-			c.logger.Info().Ctx(ctx).Msg("Withdrawer sweep complete")
+			c.logger.Info().Ctx(ctx).Msg("Withdrawer approve sweep complete")
+		case <-reconcileCh:
+			c.logger.Info().Ctx(ctx).Msg("Withdrawer reconcile sweep starting")
+			if sweepErr := c.Reconcile(ctx); sweepErr != nil {
+				c.logger.Error().Ctx(ctx).Err(sweepErr).Msg("Withdrawer reconcile sweep failed")
+			}
+			c.logger.Info().Ctx(ctx).Msg("Withdrawer reconcile sweep complete")
 		}
 	}
 }
@@ -182,6 +210,65 @@ func (c *Client) sweep(ctx context.Context) (sweepSummary, error) {
 	return summary, nil
 }
 
+// Reconcile lists every Processing withdrawal from zinc and POSTs each to
+// zinc's reconcile endpoint, which looks the transfer up at Airwallex and
+// settles/fails/parks the withdrawal server-side. Per-item failures are
+// logged and skipped — the sweep never aborts midway — and a summary tally is
+// logged at the end. Reconcile is safe to repeat: zinc responds 200 on any
+// conclusive-or-counted outcome and rejects withdrawals no longer in
+// Processing with an InvalidWithdrawalOperation error, which the sweep treats
+// as a benign skip (someone else already resolved it).
+func (c *Client) Reconcile(ctx context.Context) error {
+	summary, err := c.reconcileSweep(ctx)
+	if err != nil {
+		return err
+	}
+	c.logger.Info().Ctx(ctx).
+		Int("total", summary.total).
+		Int("succeeded", summary.succeeded).
+		Int("skipped", summary.skipped).
+		Int("failed", summary.failed).
+		Msg("Withdrawer reconcile summary")
+	return nil
+}
+
+func (c *Client) reconcileSweep(ctx context.Context) (sweepSummary, error) {
+	processing, err := c.listByStatus(ctx, "Processing")
+	if err != nil {
+		c.logger.Error().Ctx(ctx).Err(err).Msg("Failed to list processing withdrawals")
+		return sweepSummary{}, err
+	}
+
+	withdrawals := dedupeById(processing)
+	if len(withdrawals) == 0 {
+		c.logger.Info().Ctx(ctx).Msg("No withdrawals to reconcile")
+		return sweepSummary{}, nil
+	}
+
+	c.logger.Info().Ctx(ctx).Int("count", len(withdrawals)).Msg("Reconciling withdrawals")
+	summary := sweepSummary{total: len(withdrawals)}
+	for _, w := range withdrawals {
+		id := w.Id.String()
+		reconcileErr := c.reconcile(ctx, id)
+		switch {
+		case reconcileErr == nil:
+			summary.succeeded++
+			c.logger.Info().Ctx(ctx).Str("withdrawalId", id).Msg("Reconciled withdrawal")
+		case errors.Is(reconcileErr, errNotReconcilable):
+			// benign: zinc's state guard rejected the reconcile because the
+			// withdrawal is no longer in Processing — someone else (an admin, the
+			// webhook, a concurrent sweep) already resolved it. Nothing to do and
+			// nothing failed.
+			summary.skipped++
+			c.logger.Info().Ctx(ctx).Str("withdrawalId", id).Str("reason", reconcileErr.Error()).Msg("Skipped withdrawal not in a reconcilable state")
+		default:
+			summary.failed++
+			c.logger.Error().Ctx(ctx).Err(reconcileErr).Str("withdrawalId", id).Msg("Failed to reconcile withdrawal")
+		}
+	}
+	return summary, nil
+}
+
 // dedupeById drops repeated withdrawal ids, keeping first occurrences in
 // order. Skip/Limit paging in listByStatus runs over a set that shrinks while
 // paging (users cancel, admins reject mid-sweep), so an id can come back
@@ -254,8 +341,14 @@ func (c *Client) listByStatus(ctx context.Context, status string) ([]zinc.Withdr
 // Sweep treats it as a benign skip, never a failure.
 var errNotApprovable = errors.New("withdrawal is not in an approvable state")
 
-// isInvalidWithdrawalOperation reports whether a failed approve response is
-// zinc's InvalidWithdrawalOperation domain problem. zinc serialises domain
+// errNotReconcilable is the reconcile counterpart of errNotApprovable: zinc
+// rejects a reconcile with InvalidWithdrawalOperation when the withdrawal is
+// no longer in Processing (someone else already resolved it). Reconcile
+// treats it as a benign skip, never a failure.
+var errNotReconcilable = errors.New("withdrawal is not in a reconcilable state")
+
+// isInvalidWithdrawalOperation reports whether a failed approve or reconcile
+// response is zinc's InvalidWithdrawalOperation domain problem. zinc serialises domain
 // problems as RFC 7807 problem details whose type URL ends in the problem id
 // ("invalid_withdrawal_operation") when the error portal is enabled; match
 // the title too so detection survives the portal being disabled.
@@ -275,14 +368,27 @@ func isInvalidWithdrawalOperation(status int, body []byte) bool {
 }
 
 // approve calls zinc's POST /api/v1.0/Withdrawal/{id}/approve (same version segment as the generated SDK calls).
+func (c *Client) approve(ctx context.Context, id string) error {
+	return c.postWithdrawalAction(ctx, id, "approve", errNotApprovable)
+}
+
+// reconcile calls zinc's POST /api/v1.0/Withdrawal/{id}/reconcile.
+func (c *Client) reconcile(ctx context.Context, id string) error {
+	return c.postWithdrawalAction(ctx, id, "reconcile", errNotReconcilable)
+}
+
+// postWithdrawalAction calls zinc's POST /api/v1.0/Withdrawal/{id}/{action}
+// with an empty JSON body, mapping zinc's InvalidWithdrawalOperation problem
+// onto the given benign sentinel so callers can tally it as a skip.
 //
 // TODO: hand-rolled because lib/zinc/main.go (generated by oapi-codegen from a
 // running zinc instance, see scripts/local/gen-sdk.sh) predates the approve
-// endpoint. Replace this with the generated SDK method at the next regen. It
-// reuses the zinc client's exported Server, Doer and RequestEditors so auth
-// and otel instrumentation match the generated calls exactly.
-func (c *Client) approve(ctx context.Context, id string) error {
-	url := fmt.Sprintf("%s/api/v1.0/Withdrawal/%s/approve", strings.TrimSuffix(c.zinc.Server, "/"), id)
+// and reconcile endpoints. Replace this with the generated SDK methods at the
+// next regen. It reuses the zinc client's exported Server, Doer and
+// RequestEditors so auth and otel instrumentation match the generated calls
+// exactly.
+func (c *Client) postWithdrawalAction(ctx context.Context, id, action string, benign error) error {
+	url := fmt.Sprintf("%s/api/v1.0/Withdrawal/%s/%s", strings.TrimSuffix(c.zinc.Server, "/"), id, action)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader([]byte("{}")))
 	if err != nil {
 		return err
@@ -301,9 +407,9 @@ func (c *Client) approve(ctx context.Context, id string) error {
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
 		if isInvalidWithdrawalOperation(resp.StatusCode, body) {
-			return fmt.Errorf("withdrawal %s: %w: status %d: %s", id, errNotApprovable, resp.StatusCode, string(body))
+			return fmt.Errorf("withdrawal %s: %w: status %d: %s", id, benign, resp.StatusCode, string(body))
 		}
-		return fmt.Errorf("failed to approve withdrawal %s: status %d: %s", id, resp.StatusCode, string(body))
+		return fmt.Errorf("failed to %s withdrawal %s: status %d: %s", action, id, resp.StatusCode, string(body))
 	}
 	return nil
 }

--- a/lib/withdrawer/client_test.go
+++ b/lib/withdrawer/client_test.go
@@ -31,24 +31,27 @@ func wd(t *testing.T, id string) zinc.WithdrawalPrincipalRes {
 	return zinc.WithdrawalPrincipalRes{Id: u}
 }
 
-// approveResult overrides the stub's response to one withdrawal's approve
-// call; the zero value (unset map entry) means 200 OK.
+// approveResult overrides the stub's response to one withdrawal's approve or
+// reconcile call; the zero value (unset map entry) means 200 OK.
 type approveResult struct {
 	status int
 	body   string
 }
 
-// zincStub fakes the two zinc endpoints the withdrawer touches: the paged
-// Status-filtered listing and the approve endpoint. It serves pre-baked pages
-// per status (page index = Skip/Limit, beyond the last page is empty) and
-// records every approve call, so tests control paging shape — including
-// duplicates from a shrinking set — and per-item approve outcomes exactly.
+// zincStub fakes the three zinc endpoints the withdrawer touches: the paged
+// Status-filtered listing, the approve endpoint and the reconcile endpoint.
+// It serves pre-baked pages per status (page index = Skip/Limit, beyond the
+// last page is empty) and records every approve/reconcile call, so tests
+// control paging shape — including duplicates from a shrinking set — and
+// per-item outcomes exactly.
 type zincStub struct {
-	t         *testing.T
-	pages     map[string][][]zinc.WithdrawalPrincipalRes // status -> successive pages
-	approve   map[string]approveResult                   // withdrawal id -> forced response
-	approved  []string                                   // approve calls, in order
-	listCalls map[string]int                             // status -> number of list calls
+	t          *testing.T
+	pages      map[string][][]zinc.WithdrawalPrincipalRes // status -> successive pages
+	approve    map[string]approveResult                   // withdrawal id -> forced approve response
+	reconcile  map[string]approveResult                   // withdrawal id -> forced reconcile response
+	approved   []string                                   // approve calls, in order
+	reconciled []string                                   // reconcile calls, in order
+	listCalls  map[string]int                             // status -> number of list calls
 }
 
 func (s *zincStub) server() *httptest.Server {
@@ -88,6 +91,17 @@ func (s *zincStub) server() *httptest.Server {
 				return
 			}
 			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost &&
+			strings.HasPrefix(r.URL.Path, "/api/v1.0/Withdrawal/") &&
+			strings.HasSuffix(r.URL.Path, "/reconcile"):
+			id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1.0/Withdrawal/"), "/reconcile")
+			s.reconciled = append(s.reconciled, id)
+			if res, ok := s.reconcile[id]; ok {
+				w.WriteHeader(res.status)
+				_, _ = w.Write([]byte(res.body))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
 		default:
 			s.t.Errorf("unexpected zinc call: %s %s", r.Method, r.URL.Path)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -103,7 +117,7 @@ func sweepClient(t *testing.T, stub *zincStub, limit int) (*Client, func()) {
 		t.Fatal(err)
 	}
 	l := zerolog.Nop()
-	return &Client{zinc: zc, logger: &l, config: config.WithdrawerConfig{Cron: "0 0 0 * * *", Limit: limit}}, srv.Close
+	return &Client{zinc: zc, logger: &l, config: config.WithdrawerConfig{Cron: "0 0 0 * * *", ReconcileCron: "0 0 */6 * * *", Limit: limit}}, srv.Close
 }
 
 // The listing assembles all pages of a status and stops paging on the first
@@ -262,6 +276,114 @@ func TestSweepOther4xxStillCountsAsFailed(t *testing.T) {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 	if summary.total != 1 || summary.failed != 1 || summary.skipped != 0 || summary.succeeded != 0 {
+		t.Errorf("unexpected summary %+v", summary)
+	}
+}
+
+// The reconcile sweep assembles all Processing pages, stops paging on the
+// first short page, dedupes repeated ids and reconciles each exactly once —
+// and never touches the Pending listing or the approve endpoint.
+func TestReconcilePagingAssemblesPagesAndDedupes(t *testing.T) {
+	stub := &zincStub{t: t, pages: map[string][][]zinc.WithdrawalPrincipalRes{
+		// full page then a short page with a duplicate (set shrank mid-listing):
+		// paging must stop after page 2 and B must be reconciled once
+		"Processing": {
+			{wd(t, idA), wd(t, idB)},
+			{wd(t, idB), wd(t, idC)},
+		},
+	}}
+	c, closeSrv := sweepClient(t, stub, 2)
+	defer closeSrv()
+
+	summary, err := c.reconcileSweep(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	want := []string{idA, idB, idC}
+	if len(stub.reconciled) != len(want) {
+		t.Fatalf("expected reconciles %v, got %v", want, stub.reconciled)
+	}
+	for i, id := range want {
+		if stub.reconciled[i] != id {
+			t.Errorf("reconcile %d: expected %s, got %s", i, id, stub.reconciled[i])
+		}
+	}
+	// page 2 is full (dedupe happens client-side), so a third, short page is fetched
+	if stub.listCalls["Processing"] != 3 {
+		t.Errorf("expected paging to stop on the short page after 3 Processing list calls, got %d", stub.listCalls["Processing"])
+	}
+	if stub.listCalls["Pending"] != 0 {
+		t.Errorf("expected no Pending list calls from the reconcile sweep, got %d", stub.listCalls["Pending"])
+	}
+	if len(stub.approved) != 0 {
+		t.Errorf("expected no approve calls from the reconcile sweep, got %v", stub.approved)
+	}
+	if summary.total != 3 || summary.succeeded != 3 || summary.skipped != 0 || summary.failed != 0 {
+		t.Errorf("unexpected summary %+v", summary)
+	}
+}
+
+// zinc rejecting a reconcile with InvalidWithdrawalOperation (the withdrawal
+// left Processing before the sweep reached it) is benign: it must be tallied
+// as skipped, never as failed. Both problem-details shapes are recognised —
+// the type URL (error portal enabled) and the bare title (portal disabled).
+func TestReconcileSkipsBenignNotProcessingRejection(t *testing.T) {
+	stub := &zincStub{
+		t: t,
+		pages: map[string][][]zinc.WithdrawalPrincipalRes{
+			"Processing": {{wd(t, idA), wd(t, idB), wd(t, idC)}},
+		},
+		reconcile: map[string]approveResult{
+			// already resolved: rejected via the problem type URL
+			idA: {
+				status: http.StatusBadRequest,
+				body:   `{"type":"https://api.zinc.bunnybooker.com/docs/pichu/nitroso/zinc/main/v1/invalid_withdrawal_operation","title":"Invalid Withdrawal Operation","status":400}`,
+			},
+			// already resolved: rejected with the title only (error portal disabled)
+			idC: {
+				status: http.StatusConflict,
+				body:   `{"title":"Invalid Withdrawal Operation","status":409}`,
+			},
+		},
+	}
+	c, closeSrv := sweepClient(t, stub, 10)
+	defer closeSrv()
+
+	summary, err := c.reconcileSweep(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if summary.total != 3 || summary.succeeded != 1 || summary.skipped != 2 || summary.failed != 0 {
+		t.Errorf("unexpected summary %+v", summary)
+	}
+}
+
+// One failing reconcile must not abort the sweep: the remaining withdrawals
+// are still attempted and the tallies attribute exactly one failure — and a
+// 4xx that is NOT InvalidWithdrawalOperation stays a real failure.
+func TestReconcileContinuesPastFailureAndTallies(t *testing.T) {
+	stub := &zincStub{
+		t: t,
+		pages: map[string][][]zinc.WithdrawalPrincipalRes{
+			"Processing": {{wd(t, idA), wd(t, idB), wd(t, idC)}},
+		},
+		reconcile: map[string]approveResult{
+			idA: {status: http.StatusInternalServerError, body: "boom"},
+			// non-benign 4xx: must count as failed, not skipped
+			idB: {status: http.StatusBadRequest, body: `{"title":"Validation Error","status":400}`},
+		},
+	}
+	c, closeSrv := sweepClient(t, stub, 10)
+	defer closeSrv()
+
+	summary, err := c.reconcileSweep(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(stub.reconciled) != 3 {
+		t.Errorf("expected all 3 reconciles attempted despite the failures, got %v", stub.reconciled)
+	}
+	if summary.total != 3 || summary.succeeded != 1 || summary.failed != 2 || summary.skipped != 0 {
 		t.Errorf("unexpected summary %+v", summary)
 	}
 }

--- a/system/config/model.go
+++ b/system/config/model.go
@@ -97,6 +97,11 @@ type WithdrawerConfig struct {
 	// syntax with a leading SECONDS field (6 fields, dow optional), evaluated
 	// in UTC — e.g. '0 0 0 * * *' for every day at 00:00 UTC.
 	Cron string
+	// ReconcileCron is when Processing withdrawals are swept and reconciled
+	// against Airwallex via zinc's reconcile endpoint. Same robfig/cron v1
+	// syntax as Cron, evaluated in UTC — e.g. '0 0 */6 * * *' for every 6
+	// hours at 00/06/12/18 UTC.
+	ReconcileCron string
 	// Limit is the page size used when listing Pending withdrawals from zinc
 	Limit int
 }


### PR DESCRIPTION
## Summary
Second cron in the withdrawer module (`reconcileCron: '0 0 */6 * * *'`, 00/06/12/18 UTC): lists Processing withdrawals and posts each to zinc's new `POST Withdrawal/{id}/reconcile`, which looks the transfer up at Airwallex and settles, fails or parks it server-side (RequireManualIntervention after 8 inconclusive sweeps). Benign `invalid_withdrawal_operation` rejections (someone resolved it mid-sweep) tally as skipped; per-item failures never abort the sweep. The approve/reconcile HTTP calls share one helper. 3 new tests (8 total).

Companion PRs: zinc AtomiCloud/nitroso.zinc#24, argon (RMI UI).
## Test plan
go build/vet clean; 8/8 module tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new scheduled withdrawal reconciliation sweep to handle processing withdrawals automatically.
  * Exposed a new configuration option to control the reconciliation schedule.

* **Documentation**
  * Updated withdrawal scheduling comments to describe both the nightly approval sweep and the reconciliation sweep.

* **Tests**
  * Expanded coverage for pagination, duplicate handling, and retry/error behavior during reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->