### PR TITLE
feat(cli): print-ticket — re-download a ticket PDF from KTMB

### DIFF
--- a/cmds/print.go
+++ b/cmds/print.go
@@ -1,0 +1,65 @@
+package cmds
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/AtomiCloud/nitroso-tin/lib/encryptor"
+	"github.com/AtomiCloud/nitroso-tin/lib/ktmb"
+	"github.com/AtomiCloud/nitroso-tin/lib/otelredis"
+	"github.com/AtomiCloud/nitroso-tin/lib/session"
+	"github.com/urfave/cli/v2"
+)
+
+// PrintTicket re-downloads a single ticket PDF from KTMB and writes it to disk.
+// It exists to restore a ticket file that was lost from object storage for an
+// already-Completed booking, which neither `recover` (status-gated to
+// Pending/Buying/Recovering) nor zinc's guarded complete endpoint can service.
+//
+// It reuses the same login session the recoverer/buyer use (session.Login reads
+// the cached, encrypted token from Redis), so running it against a landscape's
+// live account does not create a second KTMB session. PrintTicketPdf is
+// idempotent on KTMB's side; the ticket must still belong to the enricher
+// account and not have departed.
+//
+//	print-ticket <bookingNo> <ticketNo> <outPath>
+func (state *State) PrintTicket(c *cli.Context) error {
+	args := c.Args()
+	bookingNo := args.Get(0)
+	ticketNo := args.Get(1)
+	outPath := args.Get(2)
+	if bookingNo == "" || ticketNo == "" || outPath == "" {
+		return fmt.Errorf("usage: print-ticket <bookingNo> <ticketNo> <outPath>")
+	}
+
+	ktmbConfig := state.Config.Ktmb
+	mainRedis := otelredis.New(state.Config.Cache["main"])
+	k := ktmb.New(ktmbConfig.ApiUrl, ktmbConfig.AppUrl, ktmbConfig.RequestSignature, state.Logger, ktmbConfig.Proxy, ktmb.WarmConfig{})
+	loginEncr := encryptor.NewSymEncryptor[ktmb.LoginRes](state.Config.Encryptor.Key, state.Logger)
+	s := session.New(&k, &mainRedis, state.Logger, ktmbConfig.LoginKey, loginEncr)
+
+	state.Logger.Info().
+		Str("bookingNo", bookingNo).
+		Str("ticketNo", ticketNo).
+		Msg("Reusing cached KTMB session to re-download ticket")
+
+	userData, err := s.Login(c.Context, state.Config.Enricher.Email, state.Config.Enricher.Password)
+	if err != nil {
+		state.Logger.Error().Err(err).Msg("Failed to obtain KTMB session")
+		return err
+	}
+
+	pdf, err := k.PrintTicket(userData, bookingNo, ticketNo)
+	if err != nil {
+		state.Logger.Error().Err(err).Msg("Failed to re-download ticket PDF")
+		return err
+	}
+
+	if err := os.WriteFile(outPath, pdf, 0o600); err != nil {
+		state.Logger.Error().Err(err).Str("path", outPath).Msg("Failed to write ticket PDF")
+		return err
+	}
+
+	state.Logger.Info().Int("bytes", len(pdf)).Str("path", outPath).Msg("Ticket PDF written")
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -132,6 +132,10 @@ func main() {
 				Action: state.Withdrawer,
 			},
 			{
+				Name:   "print-ticket",
+				Action: state.PrintTicket,
+			},
+			{
 				Name: "manual-buy",
 				Action: func(context *cli.Context) error {
 					buyerCfg := state.Config.Buyer


### PR DESCRIPTION
## Why

A completed zinc booking (`3a8a31bc…`, trip 2026-07-10) had its ticket PDF missing from object storage (R2). There was no way to re-obtain it:
- `recover` only acts on `Pending`/`Buying`/`Recovering` bookings — it skips `Completed`.
- Re-delivering via zinc `complete/{id}` is blocked (requires `BookingNumber == null`).

The KTMB download primitive `ktmb.PrintTicket` already exists (used by the recoverer's `forceComplete`) and is idempotent, but nothing exposed it standalone.

## What

New CLI command:

```
print-ticket <bookingNo> <ticketNo> <outPath>
```

- Logs in via `session.Login`, which **reuses the cached encrypted token in Redis** — it does not open a second KTMB session alongside the live buyer/reserver/loginer.
- Calls the existing `ktmb.PrintTicket` and writes the PDF to `outPath`.
- Reuses the exact same client wiring as `buildRecoverer` (ktmb client, encryptor, redis, enricher creds).

## Verification

Built (`go build ./...`), `go vet`, `gofmt` clean. Cross-compiled linux/amd64 and run in raichu (in a one-off pod cloned from the recoverer spec, reusing its secrets/config/Redis): reused the cached session (no new login), downloaded the correct ticket (WOODLANDS CIQ → JB SENTRAL, 2026-07-10 17:30, matching BookingNo/TicketNo), and it was re-uploaded to R2. Presigned fetch now returns HTTP 200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `print-ticket` command to download a specific ticket PDF again and save it to a chosen file path.
  * The command now validates required inputs and reports clear errors when values are missing or retrieval fails.
  * Successful downloads are saved locally with secure file permissions and confirmed with a log message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->