### PR TITLE
feat(recoverer): retry-before-duplicate via zinc recycle + missing-ticket repair sweep

### DIFF
--- a/config/app/settings.yaml
+++ b/config/app/settings.yaml
@@ -62,6 +62,21 @@ recoverer:
   drainCron: '@every 15m'
   sweepCron: '@every 1h'
   maxAttempts: 5
+  # missing-ticket repair sweep: on each sweep tick, list Completed bookings
+  # whose ticket file is missing and restore them by re-downloading the PDF
+  # from KTMB (PrintTicketPdf) and re-attaching it to zinc. Read-mostly and
+  # idempotent, so it is safe to leave enabled everywhere.
+  repairEnable: true
+  repairLimit: 100
+  # KTMB PrintTicket error substrings that DEFINITIVELY mean the booking or
+  # ticket is unknown to KTMB — only these park the booking for a human; any
+  # other error (network, 5xx, session expiry) is retried next sweep. An empty
+  # list never parks (misconfiguration degrades to retry-forever, never to a
+  # wrongful park).
+  repairNotFoundPatterns:
+    - 'not found'
+    - 'no record'
+    - 'invalid booking'
 
 withdrawer:
   # robfig/cron v1 spec with a leading seconds field, evaluated in UTC:

--- a/infra/consumer_chart/app/settings.yaml
+++ b/infra/consumer_chart/app/settings.yaml
@@ -62,6 +62,21 @@ recoverer:
   drainCron: '@every 15m'
   sweepCron: '@every 1h'
   maxAttempts: 5
+  # missing-ticket repair sweep: on each sweep tick, list Completed bookings
+  # whose ticket file is missing and restore them by re-downloading the PDF
+  # from KTMB (PrintTicketPdf) and re-attaching it to zinc. Read-mostly and
+  # idempotent, so it is safe to leave enabled everywhere.
+  repairEnable: true
+  repairLimit: 100
+  # KTMB PrintTicket error substrings that DEFINITIVELY mean the booking or
+  # ticket is unknown to KTMB — only these park the booking for a human; any
+  # other error (network, 5xx, session expiry) is retried next sweep. An empty
+  # list never parks (misconfiguration degrades to retry-forever, never to a
+  # wrongful park).
+  repairNotFoundPatterns:
+    - 'not found'
+    - 'no record'
+    - 'invalid booking'
 
 withdrawer:
   # robfig/cron v1 spec with a leading seconds field, evaluated in UTC:

--- a/lib/recoverer/client.go
+++ b/lib/recoverer/client.go
@@ -125,6 +125,13 @@ func (c *Client) Start(ctx context.Context) error {
 				if sweepErr := c.Sweep(ctx, handled); sweepErr != nil {
 					c.logger.Error().Ctx(ctx).Err(sweepErr).Msg("Recoverer sweep failed")
 				}
+				// second safety net: Completed bookings whose ticket file is
+				// missing (lost from storage or completed without an upload) are
+				// repaired by re-downloading the PDF from KTMB. Idempotent and
+				// read-mostly, so the sweep cadence is a fine fit.
+				if repairErr := c.Repair(ctx); repairErr != nil {
+					c.logger.Error().Ctx(ctx).Err(repairErr).Msg("Recoverer ticket repair failed")
+				}
 			}
 			c.logger.Info().Ctx(ctx).Str("trigger", trigger).Msg("Recoverer cycle complete")
 		}

--- a/lib/recoverer/process.go
+++ b/lib/recoverer/process.go
@@ -14,6 +14,7 @@ import (
 	"github.com/AtomiCloud/nitroso-tin/lib/buyer"
 	"github.com/AtomiCloud/nitroso-tin/lib/zinc"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 )
 
 const zincDateTimeLayout = "02-01-2006 15:04:05"
@@ -129,12 +130,77 @@ func (c *Client) ProcessItem(ctx context.Context, dto lib.RecoverDto) error {
 
 	// not on our account: the passenger holds this seat via another channel
 	// (KTMB rejected our purchase as a duplicate passport, and a definitive scan
-	// shows the ticket is not ours) — a true duplicate. Refund it. Only a
-	// DEFINITIVE absence reaches here: an inconclusive scan (empty/mutated list,
-	// unparseable row) returned an error above and is retried, never refunded, so
-	// this can never refund a booking whose ticket we actually hold.
-	l.Warn().Msg("Ticket not on our KTMB account, marking duplicate")
-	return c.markDuplicate(ctx, dto.BookingId)
+	// shows the ticket is not ours). Only a DEFINITIVE absence reaches here: an
+	// inconclusive scan (empty/mutated list, unparseable row) returned an error
+	// above and is retried, never refunded, so this can never act on a booking
+	// whose ticket we actually hold. Before refunding as a duplicate, ask zinc
+	// to recycle the booking back to Pending so the pipeline re-buys it — the
+	// "duplicate passport" rejection is often transient (e.g. the conflicting
+	// KTMB booking lapses); zinc holds the retry counter, and only once its cap
+	// is exhausted (409) do we refund as a true duplicate.
+	l.Warn().Msg("Ticket not on our KTMB account, requesting recycle before duplicate")
+	return c.recycleOrDuplicate(ctx, l, dto.BookingId)
+}
+
+// recycleOrDuplicate asks zinc to recycle a Recovering booking back to Pending
+// (POST Booking/recover-revert/{id}). zinc owns the retry counter:
+//   - 200 → booking is Pending again; the pipeline re-reserves it (subject to
+//     the normal release cooldown). Done.
+//   - 409 (recovery_retries_exhausted) → the retry budget is spent and nothing
+//     changed; fall back to markDuplicate (refund, terminal) exactly as before.
+//   - 400 → the booking state changed under us; drop the item — the sweep
+//     re-derives from zinc if anything is still stuck.
+//   - anything else (404 on an old zinc without the endpoint, 5xx, network)
+//     → error, normal requeue path.
+func (c *Client) recycleOrDuplicate(ctx context.Context, l zerolog.Logger, bookingId string) error {
+	id, err := uuid.Parse(bookingId)
+	if err != nil {
+		return err
+	}
+	resp, err := c.zinc.PostApiVVersionBookingRecoverRevertId(ctx, "1.0", id)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		ev := l.Info()
+		var b zinc.BookingPrincipalRes
+		if json.Unmarshal(body, &b) == nil && b.RecoveryRetries != nil {
+			ev = ev.Int32("recoveryRetries", *b.RecoveryRetries)
+		}
+		ev.Msg("Booking recycled Recovering -> Pending for another purchase attempt")
+		return nil
+	case http.StatusConflict:
+		// the recycle budget is spent — this is a true duplicate now; refund.
+		// Sniff the problem type purely for logging: any 409 on this endpoint
+		// means the cap (zinc changed nothing, the booking is still Recovering).
+		l.Warn().Str("problem", problemTypeOf(body)).
+			Msg("Recovery retries exhausted, marking duplicate")
+		return c.markDuplicate(ctx, bookingId)
+	case http.StatusBadRequest:
+		// state changed under us (no longer Recovering) — drop the item; the
+		// sweep re-derives from zinc if the booking still needs attention
+		l.Warn().Str("body", string(body)).
+			Msg("Recycle rejected: booking state changed under us, dropping recover item")
+		return nil
+	default:
+		return fmt.Errorf("failed to recycle booking: status %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+// problemTypeOf extracts the RFC-7807 problem "type" from a zinc error body,
+// tolerating any malformed payload (logging-only, never load-bearing).
+func problemTypeOf(body []byte) string {
+	var problem struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(body, &problem); err != nil {
+		return ""
+	}
+	return problem.Type
 }
 
 // forceComplete downloads the ticket PDF from KTMB and reports it to zinc

--- a/lib/recoverer/process_test.go
+++ b/lib/recoverer/process_test.go
@@ -17,13 +17,20 @@ const testBookingId = "b7f9c1de-4a2b-4c3d-9e8f-0a1b2c3d4e5f"
 
 // zincStub fakes the zinc endpoints the recoverer touches and records every
 // status transition it drives, so tests can assert exactly which resolution
-// (duplicate vs force-complete) was chosen.
+// (duplicate vs force-complete vs recycle) was chosen.
 type zincStub struct {
 	t            *testing.T
 	searchStatus int // 0 → 200
 	searchBody   []zinc.BookingPrincipalRes
-	duplicated   []string
-	completed    []string
+	// recycleStatus is what POST Booking/recover-revert/{id} answers (0 → 200)
+	recycleStatus int
+	// recycleBody is the raw body the recycle endpoint answers with; empty →
+	// a minimal BookingPrincipalRes
+	recycleBody string
+	duplicated  []string
+	completed   []string
+	recycled    []string
+	parked      []string
 }
 
 func (s *zincStub) server() *httptest.Server {
@@ -43,6 +50,21 @@ func (s *zincStub) server() *httptest.Server {
 		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/api/v1.0/Booking/complete/"):
 			s.completed = append(s.completed, strings.TrimPrefix(r.URL.Path, "/api/v1.0/Booking/complete/"))
 			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/api/v1.0/Booking/manual-intervention/"):
+			s.parked = append(s.parked, strings.TrimPrefix(r.URL.Path, "/api/v1.0/Booking/manual-intervention/"))
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/api/v1.0/Booking/recover-revert/"):
+			s.recycled = append(s.recycled, strings.TrimPrefix(r.URL.Path, "/api/v1.0/Booking/recover-revert/"))
+			status := s.recycleStatus
+			if status == 0 {
+				status = http.StatusOK
+			}
+			w.WriteHeader(status)
+			if s.recycleBody != "" {
+				_, _ = w.Write([]byte(s.recycleBody))
+			} else if status == http.StatusOK {
+				_, _ = w.Write([]byte(`{}`))
+			}
 		default:
 			s.t.Errorf("unexpected zinc call: %s %s", r.Method, r.URL.Path)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -121,5 +143,99 @@ func TestIsClaimedSearchFailureErrors(t *testing.T) {
 
 	if _, err := c.isClaimed(context.Background(), recoverDto(), "KTMB-K1"); err == nil {
 		t.Fatal("expected error when the claim search fails, got nil")
+	}
+}
+
+// recycleOrDuplicate is the retry-before-duplicate gate on the definitive
+// not-found path: a booking whose ticket is provably not on our KTMB account
+// is first recycled back to Pending via zinc (which owns the retry counter)
+// and only refunded as a Duplicate once zinc says the budget is spent (409).
+
+// 200 → the booking is Pending again; no duplicate transition may fire.
+func TestRecycleOrDuplicateRecycles(t *testing.T) {
+	stub := &zincStub{t: t, recycleBody: `{"recoveryRetries": 3}`}
+	c, closeSrv := conflictClient(t, stub)
+	defer closeSrv()
+
+	l := zerolog.Nop()
+	if err := c.recycleOrDuplicate(context.Background(), l, testBookingId); err != nil {
+		t.Fatalf("expected nil error on a successful recycle, got %v", err)
+	}
+	if len(stub.recycled) != 1 || stub.recycled[0] != testBookingId {
+		t.Errorf("expected exactly one recycle call for %s, got %v", testBookingId, stub.recycled)
+	}
+	if len(stub.duplicated) != 0 {
+		t.Errorf("a successful recycle must not mark duplicate, got %v", stub.duplicated)
+	}
+}
+
+// 409 (recovery_retries_exhausted) → the budget is spent: fall back to
+// markDuplicate exactly as the pre-recycle behavior did.
+func TestRecycleOrDuplicateExhaustedFallsBackToDuplicate(t *testing.T) {
+	stub := &zincStub{t: t, recycleStatus: http.StatusConflict,
+		recycleBody: `{"type":"recovery_retries_exhausted","title":"..."}`}
+	c, closeSrv := conflictClient(t, stub)
+	defer closeSrv()
+
+	l := zerolog.Nop()
+	if err := c.recycleOrDuplicate(context.Background(), l, testBookingId); err != nil {
+		t.Fatalf("expected nil error when falling back to duplicate, got %v", err)
+	}
+	if len(stub.duplicated) != 1 || stub.duplicated[0] != testBookingId {
+		t.Errorf("expected exactly one duplicate transition for %s, got %v", testBookingId, stub.duplicated)
+	}
+}
+
+// 400 → the booking state changed under us: drop the item (nil) without any
+// transition; the sweep re-derives from zinc if it is still stuck.
+func TestRecycleOrDuplicateBadRequestDropsItem(t *testing.T) {
+	stub := &zincStub{t: t, recycleStatus: http.StatusBadRequest,
+		recycleBody: `{"type":"invalid_booking_operation"}`}
+	c, closeSrv := conflictClient(t, stub)
+	defer closeSrv()
+
+	l := zerolog.Nop()
+	if err := c.recycleOrDuplicate(context.Background(), l, testBookingId); err != nil {
+		t.Fatalf("expected nil error (drop) on 400, got %v", err)
+	}
+	if len(stub.duplicated) != 0 {
+		t.Errorf("a 400 must not mark duplicate, got %v", stub.duplicated)
+	}
+}
+
+// Any other status (e.g. 404 from an old zinc without the endpoint, or a 5xx)
+// is transient: surface an error so the caller requeues — never a silent
+// duplicate, and never a silent drop.
+func TestRecycleOrDuplicateOtherStatusErrors(t *testing.T) {
+	for _, status := range []int{http.StatusNotFound, http.StatusBadGateway} {
+		stub := &zincStub{t: t, recycleStatus: status}
+		c, closeSrv := conflictClient(t, stub)
+
+		l := zerolog.Nop()
+		err := c.recycleOrDuplicate(context.Background(), l, testBookingId)
+		closeSrv()
+		if err == nil {
+			t.Errorf("expected error on recycle status %d, got nil", status)
+		}
+		if len(stub.duplicated) != 0 {
+			t.Errorf("status %d must not mark duplicate, got %v", status, stub.duplicated)
+		}
+	}
+}
+
+// problemTypeOf is logging-only and must tolerate garbage.
+func TestProblemTypeOf(t *testing.T) {
+	cases := []struct {
+		body string
+		want string
+	}{
+		{`{"type":"recovery_retries_exhausted"}`, "recovery_retries_exhausted"},
+		{`not json`, ""},
+		{``, ""},
+	}
+	for _, tc := range cases {
+		if got := problemTypeOf([]byte(tc.body)); got != tc.want {
+			t.Errorf("problemTypeOf(%q) = %q, want %q", tc.body, got, tc.want)
+		}
 	}
 }

--- a/lib/recoverer/repair.go
+++ b/lib/recoverer/repair.go
@@ -1,0 +1,198 @@
+package recoverer
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/AtomiCloud/nitroso-tin/lib"
+	"github.com/AtomiCloud/nitroso-tin/lib/buyer"
+	"github.com/AtomiCloud/nitroso-tin/lib/zinc"
+	"github.com/google/uuid"
+)
+
+// ticketPrinter downloads a ticket PDF from KTMB by its identifiers. It is a
+// function seam so the repair decision logic is testable without a live KTMB
+// session (mirrors the pageFetcher seam in scan.go).
+type ticketPrinter func(bookingNo, ticketNo string) ([]byte, error)
+
+// Repair is the missing-ticket repair sweep: it lists Completed bookings whose
+// ticket file reference is gone (lost from object storage, or completed via a
+// path that never uploaded one) and restores each by re-downloading the PDF
+// from KTMB and re-attaching it via zinc's Booking/ticket endpoint.
+//
+// The sweep is read-mostly and idempotent: re-attaching the same ticket is
+// harmless, so per-item transient failures are just logged — the next sweep
+// retries naturally, no queue involvement. Only two conditions park a booking
+// for a human (RequireManualIntervention): missing KTMB identifiers (zinc has
+// no BookingNo/TicketNo, so nothing can be re-downloaded) and a DEFINITIVE
+// KTMB "booking/ticket unknown" rejection. Departed bookings are still
+// attempted — KTMB's PrintTicketPdf may well serve a past ticket — and any
+// inconclusive error on them just logs and moves on.
+func (c *Client) Repair(ctx context.Context) error {
+	if !c.config.RepairEnable {
+		c.logger.Info().Ctx(ctx).Msg("Ticket repair sweep disabled, skipping")
+		return nil
+	}
+
+	bookings, err := c.listMissingTickets(ctx)
+	if err != nil {
+		c.logger.Error().Ctx(ctx).Err(err).Msg("Failed to list missing-ticket bookings for repair sweep")
+		return err
+	}
+	if len(bookings) == 0 {
+		return nil
+	}
+	c.logger.Info().Ctx(ctx).Int("count", len(bookings)).Msg("Repairing completed bookings with missing tickets")
+
+	// one login for the whole sweep (session.Login serves a cached token)
+	userData, err := c.session.Login(ctx, c.enricher.Email, c.enricher.Password)
+	if err != nil {
+		c.logger.Error().Ctx(ctx).Err(err).Msg("Failed to login to KTMB for repair sweep")
+		return err
+	}
+	print := func(bookingNo, ticketNo string) ([]byte, error) {
+		return c.ktmb.PrintTicket(userData, bookingNo, ticketNo)
+	}
+
+	c.repairBookings(ctx, bookings, print)
+	return nil
+}
+
+// repairBookings runs the per-booking repair decision over one sweep's page.
+// Per-item failures never abort the sweep.
+func (c *Client) repairBookings(ctx context.Context, bookings []zinc.BookingPrincipalRes, print ticketPrinter) {
+	for _, b := range bookings {
+		c.repairOne(ctx, b, print)
+	}
+}
+
+// repairOne restores a single Completed booking's missing ticket file:
+//
+//   - zinc has both KTMB identifiers → PrintTicket → upload to zinc.
+//   - identifiers missing → a human must source the ticket: park it.
+//   - KTMB definitively does not know the booking/ticket → park it.
+//   - anything inconclusive (network, 5xx, session hiccup, empty PDF, upload
+//     failure) → log and move on; the next sweep retries.
+func (c *Client) repairOne(ctx context.Context, b zinc.BookingPrincipalRes, print ticketPrinter) {
+	bookingId := b.Id.String()
+	bookingNo := lib.Deref(b.BookingNo)
+	ticketNo := lib.Deref(b.TicketNo)
+	l := c.logger.With().Ctx(ctx).Str("bookingId", bookingId).Str("bookingNo", bookingNo).Str("ticketNo", ticketNo).Logger()
+
+	if bookingNo == "" || ticketNo == "" {
+		// nothing to re-download with — only a human can source this ticket
+		l.Error().Msg("Completed booking has no ticket file and no KTMB identifiers, parking for manual intervention")
+		if err := c.markManualIntervention(ctx, bookingId); err != nil {
+			l.Error().Err(err).Msg("Failed to park identifier-less booking for manual intervention")
+		}
+		return
+	}
+
+	pdf, err := print(bookingNo, ticketNo)
+	if err != nil {
+		if matchesNotFound(c.config.RepairNotFoundPatterns, err) {
+			// KTMB definitively does not know this booking/ticket — re-download
+			// can never succeed; a human must source the ticket
+			l.Error().Err(err).Msg("KTMB does not know this booking/ticket, parking for manual intervention")
+			if miErr := c.markManualIntervention(ctx, bookingId); miErr != nil {
+				l.Error().Err(miErr).Msg("Failed to park unknown-ticket booking for manual intervention")
+			}
+			return
+		}
+		// inconclusive (network, 5xx, session expiry, departed-ticket oddity):
+		// never park on ambiguity — the next sweep retries for free
+		l.Warn().Err(err).Msg("KTMB ticket re-download failed inconclusively, will retry next sweep")
+		return
+	}
+	if len(pdf) == 0 {
+		// an empty body with a 2xx is a scrape anomaly, not a verdict — retry
+		l.Warn().Msg("KTMB returned an empty ticket PDF, will retry next sweep")
+		return
+	}
+
+	if err := c.uploadTicket(ctx, bookingId, bookingNo, ticketNo, pdf); err != nil {
+		l.Warn().Err(err).Msg("Failed to upload repaired ticket to zinc, will retry next sweep")
+		return
+	}
+	l.Info().Int("bytes", len(pdf)).Msg("Repaired missing ticket file on completed booking")
+}
+
+// listMissingTickets fetches one page (RepairLimit) of Completed bookings that
+// carry no ticket file reference. One page per sweep is deliberate: the
+// backlog should be near-zero in steady state, and a bounded page keeps the
+// sweep's KTMB traffic modest; leftovers are picked up next sweep.
+func (c *Client) listMissingTickets(ctx context.Context) ([]zinc.BookingPrincipalRes, error) {
+	completed := "Completed"
+	missing := true
+	limit := int32(c.config.RepairLimit)
+	resp, err := c.zinc.GetApiVVersionBooking(ctx, "1.0", &zinc.GetApiVVersionBookingParams{
+		Status:        &completed,
+		MissingTicket: &missing,
+		Limit:         &limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to list missing-ticket bookings: status %d: %s", resp.StatusCode, string(content))
+	}
+	var bookings []zinc.BookingPrincipalRes
+	if err := json.Unmarshal(content, &bookings); err != nil {
+		return nil, err
+	}
+	return bookings, nil
+}
+
+// uploadTicket attaches the re-downloaded PDF to the Completed booking via
+// zinc's ticket-repair endpoint (multipart, like completeBooking).
+func (c *Client) uploadTicket(ctx context.Context, bookingId, bookingNo, ticketNo string, pdf []byte) error {
+	id, err := uuid.Parse(bookingId)
+	if err != nil {
+		return err
+	}
+	contentType, rr, err := buyer.CreateForm(map[string]io.Reader{
+		"file": bytes.NewReader(pdf),
+	})
+	if err != nil {
+		return err
+	}
+	resp, err := c.zinc.PostApiVVersionBookingTicketIdWithBody(ctx, "1.0", id, &zinc.PostApiVVersionBookingTicketIdParams{
+		BookingNo: &bookingNo,
+		TicketNo:  &ticketNo,
+	}, contentType, rr)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to attach ticket to booking: status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// matchesNotFound reports whether a KTMB PrintTicket error DEFINITIVELY means
+// the booking/ticket is unknown to KTMB, by case-insensitive substring match
+// against the configured patterns (same style as the buyer's
+// conflictPatterns). No match — including an empty pattern list — reads as
+// inconclusive, so misconfiguration degrades to "retry forever", never to a
+// wrongful manual-intervention park.
+func matchesNotFound(patterns []string, err error) bool {
+	msg := strings.ToLower(err.Error())
+	for _, p := range patterns {
+		if p != "" && strings.Contains(msg, strings.ToLower(p)) {
+			return true
+		}
+	}
+	return false
+}

--- a/lib/recoverer/repair_test.go
+++ b/lib/recoverer/repair_test.go
@@ -1,0 +1,259 @@
+package recoverer
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/AtomiCloud/nitroso-tin/lib/zinc"
+	"github.com/AtomiCloud/nitroso-tin/system/config"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+// repairZincStub fakes the two zinc endpoints the repair sweep writes to:
+// the ticket upload and the manual-intervention transition.
+type repairZincStub struct {
+	t            *testing.T
+	uploadStatus int // 0 → 200
+	uploaded     []string
+	uploadQuery  []string
+	parked       []string
+}
+
+func (s *repairZincStub) server() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/api/v1.0/Booking/ticket/"):
+			s.uploaded = append(s.uploaded, strings.TrimPrefix(r.URL.Path, "/api/v1.0/Booking/ticket/"))
+			s.uploadQuery = append(s.uploadQuery, r.URL.RawQuery)
+			if s.uploadStatus != 0 && s.uploadStatus != http.StatusOK {
+				w.WriteHeader(s.uploadStatus)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/api/v1.0/Booking/manual-intervention/"):
+			s.parked = append(s.parked, strings.TrimPrefix(r.URL.Path, "/api/v1.0/Booking/manual-intervention/"))
+			w.WriteHeader(http.StatusOK)
+		default:
+			s.t.Errorf("unexpected zinc call: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+}
+
+func repairClient(t *testing.T, stub *repairZincStub) (*Client, func()) {
+	t.Helper()
+	srv := stub.server()
+	zc, err := zinc.NewClient(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l := zerolog.Nop()
+	return &Client{
+		zinc:   zc,
+		logger: &l,
+		loc:    sgLoc(t),
+		config: config.RecovererConfig{
+			RepairEnable:           true,
+			RepairLimit:            100,
+			RepairNotFoundPatterns: []string{"not found", "no record"},
+		},
+	}, srv.Close
+}
+
+func completedBooking(t *testing.T, bookingNo, ticketNo string) zinc.BookingPrincipalRes {
+	t.Helper()
+	status := "Completed"
+	id, err := uuid.Parse(testBookingId)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := zinc.BookingPrincipalRes{Id: id, Status: &status}
+	if bookingNo != "" {
+		b.BookingNo = &bookingNo
+	}
+	if ticketNo != "" {
+		b.TicketNo = &ticketNo
+	}
+	return b
+}
+
+// The repair sweep's decision logic (spec): identifiers present + KTMB serves
+// the PDF → upload to zinc; identifiers missing or KTMB definitively unknown →
+// park for a human; anything inconclusive → do nothing (next sweep retries).
+
+// Happy path: both identifiers present, PrintTicket succeeds → PDF is uploaded
+// with the identifiers as query params; nothing is parked.
+func TestRepairOneUploadsTicket(t *testing.T) {
+	stub := &repairZincStub{t: t}
+	c, closeSrv := repairClient(t, stub)
+	defer closeSrv()
+
+	print := func(bookingNo, ticketNo string) ([]byte, error) {
+		if bookingNo != "KTMB-K1" || ticketNo != "T-1" {
+			t.Errorf("print called with (%q, %q), want (KTMB-K1, T-1)", bookingNo, ticketNo)
+		}
+		return []byte("%PDF-fake"), nil
+	}
+	c.repairOne(context.Background(), completedBooking(t, "KTMB-K1", "T-1"), print)
+
+	if len(stub.uploaded) != 1 || stub.uploaded[0] != testBookingId {
+		t.Fatalf("expected one upload for %s, got %v", testBookingId, stub.uploaded)
+	}
+	if !strings.Contains(stub.uploadQuery[0], "bookingNo=KTMB-K1") || !strings.Contains(stub.uploadQuery[0], "ticketNo=T-1") {
+		t.Errorf("upload query must carry identifiers, got %q", stub.uploadQuery[0])
+	}
+	if len(stub.parked) != 0 {
+		t.Errorf("happy path must not park, got %v", stub.parked)
+	}
+}
+
+// Missing identifiers: nothing can be re-downloaded — a human must source the
+// ticket. Park, never call KTMB.
+func TestRepairOneMissingIdentifiersParks(t *testing.T) {
+	for _, b := range []zinc.BookingPrincipalRes{
+		completedBooking(t, "", ""),
+		completedBooking(t, "KTMB-K1", ""),
+		completedBooking(t, "", "T-1"),
+	} {
+		stub := &repairZincStub{t: t}
+		c, closeSrv := repairClient(t, stub)
+
+		printed := false
+		c.repairOne(context.Background(), b, func(string, string) ([]byte, error) {
+			printed = true
+			return nil, fmt.Errorf("must not be called")
+		})
+		closeSrv()
+
+		if printed {
+			t.Error("KTMB must not be called when identifiers are missing")
+		}
+		if len(stub.parked) != 1 || stub.parked[0] != testBookingId {
+			t.Errorf("expected manual-intervention park, got %v", stub.parked)
+		}
+		if len(stub.uploaded) != 0 {
+			t.Errorf("must not upload without a PDF, got %v", stub.uploaded)
+		}
+	}
+}
+
+// A KTMB error matching a not-found pattern is definitive: the ticket can
+// never be re-downloaded — park for a human.
+func TestRepairOneKtmbNotFoundParks(t *testing.T) {
+	stub := &repairZincStub{t: t}
+	c, closeSrv := repairClient(t, stub)
+	defer closeSrv()
+
+	print := func(string, string) ([]byte, error) {
+		return nil, fmt.Errorf("status code 400, body Booking Not Found")
+	}
+	c.repairOne(context.Background(), completedBooking(t, "KTMB-K1", "T-1"), print)
+
+	if len(stub.parked) != 1 || stub.parked[0] != testBookingId {
+		t.Errorf("expected manual-intervention park on definitive not-found, got %v", stub.parked)
+	}
+	if len(stub.uploaded) != 0 {
+		t.Errorf("must not upload on not-found, got %v", stub.uploaded)
+	}
+}
+
+// Any other KTMB error is inconclusive (network, 5xx, session expiry, a
+// departed ticket behaving oddly): do nothing — the next sweep retries. This
+// also covers the misconfiguration case (empty pattern list): degrade to
+// retry-forever, never to a wrongful park.
+func TestRepairOneTransientKtmbErrorRetriesNextSweep(t *testing.T) {
+	stub := &repairZincStub{t: t}
+	c, closeSrv := repairClient(t, stub)
+	defer closeSrv()
+
+	print := func(string, string) ([]byte, error) {
+		return nil, fmt.Errorf("connection reset by peer")
+	}
+	c.repairOne(context.Background(), completedBooking(t, "KTMB-K1", "T-1"), print)
+
+	if len(stub.parked) != 0 {
+		t.Errorf("transient errors must not park, got %v", stub.parked)
+	}
+	if len(stub.uploaded) != 0 {
+		t.Errorf("transient errors must not upload, got %v", stub.uploaded)
+	}
+}
+
+// An empty 2xx PDF is a scrape anomaly, not a verdict: retry next sweep.
+func TestRepairOneEmptyPdfRetriesNextSweep(t *testing.T) {
+	stub := &repairZincStub{t: t}
+	c, closeSrv := repairClient(t, stub)
+	defer closeSrv()
+
+	c.repairOne(context.Background(), completedBooking(t, "KTMB-K1", "T-1"),
+		func(string, string) ([]byte, error) { return []byte{}, nil })
+
+	if len(stub.parked) != 0 || len(stub.uploaded) != 0 {
+		t.Errorf("empty PDF must neither park nor upload, got parked=%v uploaded=%v", stub.parked, stub.uploaded)
+	}
+}
+
+// A failed upload is transient too: the PDF is re-downloadable, so just log
+// and let the next sweep retry — never park.
+func TestRepairOneUploadFailureRetriesNextSweep(t *testing.T) {
+	stub := &repairZincStub{t: t, uploadStatus: http.StatusBadGateway}
+	c, closeSrv := repairClient(t, stub)
+	defer closeSrv()
+
+	c.repairOne(context.Background(), completedBooking(t, "KTMB-K1", "T-1"),
+		func(string, string) ([]byte, error) { return []byte("%PDF-fake"), nil })
+
+	if len(stub.parked) != 0 {
+		t.Errorf("upload failure must not park, got %v", stub.parked)
+	}
+}
+
+// Per-item failures never abort the sweep: a parked booking and a transient
+// failure must not stop later bookings from being repaired.
+func TestRepairBookingsContinuesPastFailures(t *testing.T) {
+	stub := &repairZincStub{t: t}
+	c, closeSrv := repairClient(t, stub)
+	defer closeSrv()
+
+	good := completedBooking(t, "KTMB-K2", "T-2")
+	bookings := []zinc.BookingPrincipalRes{
+		completedBooking(t, "", ""), // parks
+		good,                        // repairs
+	}
+	c.repairBookings(context.Background(), bookings, func(bookingNo, ticketNo string) ([]byte, error) {
+		return []byte("%PDF-fake"), nil
+	})
+
+	if len(stub.parked) != 1 {
+		t.Errorf("expected the identifier-less booking parked, got %v", stub.parked)
+	}
+	if len(stub.uploaded) != 1 {
+		t.Errorf("expected the healthy booking repaired despite the earlier park, got %v", stub.uploaded)
+	}
+}
+
+// matchesNotFound is the definitive-vs-transient classifier; pin its matching
+// semantics (case-insensitive substring, empty patterns never match).
+func TestMatchesNotFound(t *testing.T) {
+	cases := []struct {
+		patterns []string
+		err      string
+		want     bool
+	}{
+		{[]string{"not found"}, "status code 400, body Booking NOT FOUND", true},
+		{[]string{"no record"}, "No Record Exists", true},
+		{[]string{"not found"}, "connection refused", false},
+		{nil, "booking not found", false},
+		{[]string{""}, "anything", false},
+	}
+	for _, tc := range cases {
+		if got := matchesNotFound(tc.patterns, fmt.Errorf("%s", tc.err)); got != tc.want {
+			t.Errorf("matchesNotFound(%v, %q) = %t, want %t", tc.patterns, tc.err, got, tc.want)
+		}
+	}
+}

--- a/lib/zinc/main.go
+++ b/lib/zinc/main.go
@@ -64,6 +64,11 @@ type BookingPrincipalRes struct {
 	TicketLink  *string             `json:"ticketLink"`
 	TicketNo    *string             `json:"ticketNo"`
 	Time        *string             `json:"time"`
+	// RecoveryRetries is how many times zinc has recycled this booking from
+	// Recovering back to Pending (counter held zinc-side, capped by config).
+	// NOTE: manually added for the zinc recovery-retry contract (zinc PR #35);
+	// regenerate via `pls sdk:gen` against a zinc carrying that PR to reconcile.
+	RecoveryRetries *int32 `json:"recoveryRetries,omitempty"`
 }
 
 // BookingRes defines model for BookingRes.
@@ -433,6 +438,10 @@ type GetApiVVersionBookingParams struct {
 	PassportNumber *string `form:"PassportNumber,omitempty" json:"PassportNumber,omitempty"`
 	Limit          *int32  `form:"Limit,omitempty" json:"Limit,omitempty"`
 	Skip           *int32  `form:"Skip,omitempty" json:"Skip,omitempty"`
+	// MissingTicket filters to bookings that carry no ticket file reference.
+	// NOTE: manually added for the zinc recovery-retry contract (zinc PR #35);
+	// regenerate via `pls sdk:gen` against a zinc carrying that PR to reconcile.
+	MissingTicket *bool `form:"MissingTicket,omitempty" json:"MissingTicket,omitempty"`
 }
 
 // PostApiVVersionBookingCancelIdParams defines parameters for PostApiVVersionBookingCancelId.
@@ -452,6 +461,14 @@ type PostApiVVersionBookingCompleteIdMultipartBody struct {
 
 // PostApiVVersionBookingCompleteIdParams defines parameters for PostApiVVersionBookingCompleteId.
 type PostApiVVersionBookingCompleteIdParams struct {
+	BookingNo *string `form:"bookingNo,omitempty" json:"bookingNo,omitempty"`
+	TicketNo  *string `form:"ticketNo,omitempty" json:"ticketNo,omitempty"`
+}
+
+// PostApiVVersionBookingTicketIdParams defines parameters for PostApiVVersionBookingTicketId.
+// NOTE: manually added for the zinc recovery-retry contract (zinc PR #35);
+// regenerate via `pls sdk:gen` against a zinc carrying that PR to reconcile.
+type PostApiVVersionBookingTicketIdParams struct {
 	BookingNo *string `form:"bookingNo,omitempty" json:"bookingNo,omitempty"`
 	TicketNo  *string `form:"ticketNo,omitempty" json:"ticketNo,omitempty"`
 }
@@ -753,6 +770,22 @@ type ClientInterface interface {
 	// revert endpoint; only the raw method is provided, no WithResponse variant.
 	// Regenerate via `pls sdk:gen` against zinc >= 1.36 to reconcile this file.
 	PostApiVVersionBookingRevertId(ctx context.Context, version string, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostApiVVersionBookingRecoverRevertId request
+	// NOTE: manually added for the zinc recovery-retry contract (zinc PR #35):
+	// recycles a Recovering booking back to Pending, bumping zinc's retry
+	// counter. 409 (problem type recovery_retries_exhausted) means the cap is
+	// reached. Only the raw method is provided, no WithResponse variant.
+	// Regenerate via `pls sdk:gen` against a zinc carrying that PR to reconcile.
+	PostApiVVersionBookingRecoverRevertId(ctx context.Context, version string, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostApiVVersionBookingTicketIdWithBody request with any body
+	// NOTE: manually added for the zinc recovery-retry contract (zinc PR #35):
+	// attaches/replaces the ticket PDF (multipart `file`) on a Completed
+	// booking. Only the raw with-body method is provided, no WithResponse
+	// variant. Regenerate via `pls sdk:gen` against a zinc carrying that PR to
+	// reconcile.
+	PostApiVVersionBookingTicketIdWithBody(ctx context.Context, version string, id openapi_types.UUID, params *PostApiVVersionBookingTicketIdParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostApiVVersionBookingCancelId request
 	PostApiVVersionBookingCancelId(ctx context.Context, version string, id openapi_types.UUID, params *PostApiVVersionBookingCancelIdParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1094,6 +1127,30 @@ func (c *Client) PostApiVVersionBookingBuyingId(ctx context.Context, version str
 
 func (c *Client) PostApiVVersionBookingRevertId(ctx context.Context, version string, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPostApiVVersionBookingRevertIdRequest(c.Server, version, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostApiVVersionBookingRecoverRevertId(ctx context.Context, version string, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostApiVVersionBookingRecoverRevertIdRequest(c.Server, version, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostApiVVersionBookingTicketIdWithBody(ctx context.Context, version string, id openapi_types.UUID, params *PostApiVVersionBookingTicketIdParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostApiVVersionBookingTicketIdRequestWithBody(c.Server, version, id, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2434,6 +2491,22 @@ func NewGetApiVVersionBookingRequest(server string, version string, params *GetA
 
 		}
 
+		if params.MissingTicket != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "MissingTicket", runtime.ParamLocationQuery, *params.MissingTicket); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 
@@ -2523,6 +2596,130 @@ func NewPostApiVVersionBookingRevertIdRequest(server string, version string, id 
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewPostApiVVersionBookingRecoverRevertIdRequest generates requests for PostApiVVersionBookingRecoverRevertId.
+// NOTE: manually added for the zinc recovery-retry contract (zinc PR #35).
+func NewPostApiVVersionBookingRecoverRevertIdRequest(server string, version string, id openapi_types.UUID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "version", runtime.ParamLocationPath, version)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v%s/Booking/recover-revert/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPostApiVVersionBookingTicketIdRequestWithBody generates requests for PostApiVVersionBookingTicketId with any type of body.
+// NOTE: manually added for the zinc recovery-retry contract (zinc PR #35).
+func NewPostApiVVersionBookingTicketIdRequestWithBody(server string, version string, id openapi_types.UUID, params *PostApiVVersionBookingTicketIdParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "version", runtime.ParamLocationPath, version)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v%s/Booking/ticket/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.BookingNo != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "bookingNo", runtime.ParamLocationQuery, *params.BookingNo); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.TicketNo != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "ticketNo", runtime.ParamLocationQuery, *params.TicketNo); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }

--- a/system/config/model.go
+++ b/system/config/model.go
@@ -89,6 +89,20 @@ type RecovererConfig struct {
 	// MaxAttempts is how many drain cycles an item may fail before it is
 	// parked as RequireManualIntervention
 	MaxAttempts int
+	// RepairEnable turns on the missing-ticket repair sweep: each sweep tick
+	// also lists Completed bookings whose ticket file is missing and restores
+	// them by re-downloading the PDF from KTMB and re-attaching it to zinc.
+	// Read-mostly and idempotent.
+	RepairEnable bool
+	// RepairLimit bounds how many missing-ticket bookings one repair sweep
+	// processes (a single zinc page; leftovers are picked up next sweep).
+	RepairLimit int
+	// RepairNotFoundPatterns are case-insensitive substrings of KTMB
+	// PrintTicket error messages that DEFINITIVELY mean the booking/ticket is
+	// unknown to KTMB (same matching style as Buyer.ConflictPatterns). A match
+	// parks the booking as RequireManualIntervention; any other error is
+	// treated as transient and retried next sweep. An empty list never parks.
+	RepairNotFoundPatterns []string
 }
 
 // Withdrawer Config


### PR DESCRIPTION
## What

Two recoverer features against the new zinc recovery-retry contract (AtomiCloud/nitroso.zinc PR #35, branch `feat/recovery-retry-ticket-repair`):

### A. Retry-before-duplicate (`lib/recoverer/process.go`)

At the definitive "ticket not on our KTMB account" site in `ProcessItem`, instead of immediately marking the booking `Duplicate` (refund, terminal), tin now asks zinc to recycle it back to `Pending` via `POST api/v1/Booking/recover-revert/{id}` — zinc owns the retry counter (max 10 via zinc config). Outcome handling:

- **200** → booking is Pending again; the pipeline re-reserves it under the normal release cooldown. Logs `recoveryRetries` from the response.
- **409** `recovery_retries_exhausted` → budget spent, fall back to `markDuplicate` exactly as before.
- **400** (state changed under us) → drop the item; the sweep re-derives from zinc.
- anything else (404 on old zinc, 5xx, network) → error → normal requeue path.

The *claimed-by-another-booking* duplicate site is untouched (true duplicate). The drain-cycle `MaxAttempts` transient-retry cap is a separate concept and is also untouched.

### B. Missing-ticket repair sweep (`lib/recoverer/repair.go`)

On each existing sweep tick (same single-replica cron process), list Completed bookings with `MissingTicket=true&Status=Completed&Limit=repairLimit` and repair each:

- BookingNo + TicketNo present → KTMB login (cached session) + `PrintTicketPdf` → upload via `POST api/v1/Booking/ticket/{id}` (multipart, like `completeBooking`).
- Identifiers missing, or KTMB **definitively** unknown (configurable `repairNotFoundPatterns`, matched like the buyer's `conflictPatterns`) → `markManualIntervention`.
- Any inconclusive error (network/5xx/session/empty PDF/upload failure) → log and move on; next sweep retries naturally (idempotent, no queue).
- Departed bookings are still attempted — PrintTicketPdf may serve past tickets; only a definitive not-found parks them.

Config knobs (`recoverer` section): `repairEnable` (default true), `repairLimit` (100), `repairNotFoundPatterns`. Synced to `infra/consumer_chart/app/` by the config-sync hook.

### SDK (`lib/zinc/main.go`, hand-added per existing precedent)

- `PostApiVVersionBookingRecoverRevertId`
- `PostApiVVersionBookingTicketIdWithBody` + params
- `GetApiVVersionBookingParams.MissingTicket`
- `BookingPrincipalRes.RecoveryRetries`

Regenerate with `pls sdk:gen` once zinc PR #35 is released to reconcile.

## Why

Recovering bookings whose ticket is provably not ours were refunded as duplicates on the first definitive scan, even though the "duplicate passport" condition on KTMB is often transient — the recycle path lets the pipeline re-buy up to zinc's cap before refunding. Separately, Completed bookings can lose their ticket file (storage loss, legacy completion paths); PR #38's print-ticket CLI proved KTMB re-download works, and this automates it.

## Deployment ordering

**Requires zinc PR #35 deployed first.** Against an older zinc the recover-revert call returns 404, which tin deliberately treats as a transient error → requeue (never a wrongful refund or drop), so nothing breaks — but the recycle feature does nothing until zinc is updated. Deploy tin **after** zinc.

## Validation

- `go build ./...` green
- `go test ./...` green (note: on this dev machine the test binaries need `-ldflags=-linkmode=external` due to a local dyld/LC_UUID nix quirk; CI is unaffected)
- `go vet ./...` + `gofmt` clean (repo's golangci-lint pre-commit hook is disabled; CI runs pre-commit only)
- New unit tests: recycle decision table (200/409/400/404/5xx), repair decision table (upload happy path incl. query params, missing identifiers park, definitive not-found park, transient/empty-PDF/upload-failure retry, sweep continues past failures, pattern matcher semantics)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic repair sweeps for completed bookings with missing ticket files.
  * Successfully recovered tickets are re-downloaded and attached to the booking.
  * Unresolved or definitively missing tickets are routed for manual intervention.
  * Recoverable “not found” bookings are retried before being classified as duplicates or refunded.
  * Added configuration to enable repairs, limit sweep size, and recognize ticket-not-found errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->