### PR TITLE
feat(withdrawer): runtime sweep gate from zinc settings

### DIFF
--- a/config/app/settings.yaml
+++ b/config/app/settings.yaml
@@ -79,10 +79,14 @@ recoverer:
     - 'invalid booking'
 
 withdrawer:
-  # gate for the approve sweep: false = withdrawals pay out only when a human
-  # clicks approve in zinc (the reconcile sweep below keeps running either way
-  # so in-flight payouts still settle)
-  approveEnable: false
+  # deploy-level killswitch for the approve sweep. Two-gate model: this static
+  # flag AND zinc's runtime sweepEnabled setting (admin-flippable in the zinc
+  # UI, default off server-side) must BOTH be on for a sweep tick to run —
+  # flipping this to true does not start sweeping until an admin also enables
+  # it in zinc. false = withdrawals pay out only when a human clicks approve in
+  # zinc, regardless of the zinc setting (the reconcile sweep below keeps
+  # running either way so in-flight payouts still settle).
+  approveEnable: true
   # robfig/cron v1 spec with a leading seconds field, evaluated in UTC:
   # '0 0 0 * * *' = every day at 00:00:00 UTC
   cron: '0 0 0 * * *'

--- a/infra/consumer_chart/app/settings.yaml
+++ b/infra/consumer_chart/app/settings.yaml
@@ -79,10 +79,14 @@ recoverer:
     - 'invalid booking'
 
 withdrawer:
-  # gate for the approve sweep: false = withdrawals pay out only when a human
-  # clicks approve in zinc (the reconcile sweep below keeps running either way
-  # so in-flight payouts still settle)
-  approveEnable: false
+  # deploy-level killswitch for the approve sweep. Two-gate model: this static
+  # flag AND zinc's runtime sweepEnabled setting (admin-flippable in the zinc
+  # UI, default off server-side) must BOTH be on for a sweep tick to run —
+  # flipping this to true does not start sweeping until an admin also enables
+  # it in zinc. false = withdrawals pay out only when a human clicks approve in
+  # zinc, regardless of the zinc setting (the reconcile sweep below keeps
+  # running either way so in-flight payouts still settle).
+  approveEnable: true
   # robfig/cron v1 spec with a leading seconds field, evaluated in UTC:
   # '0 0 0 * * *' = every day at 00:00:00 UTC
   cron: '0 0 0 * * *'

--- a/lib/withdrawer/client.go
+++ b/lib/withdrawer/client.go
@@ -115,12 +115,28 @@ func (c *Client) Start(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-approveCh:
-			// approvals can be turned off (withdrawals then only pay out when a
-			// human clicks approve in zinc) while the reconcile sweep keeps
-			// running — in-flight Processing payouts must still settle
-			if !c.config.ApproveEnable {
+			// TWO-GATE MODEL: the static config flag (withdrawer.approveEnable) is
+			// the deploy-level killswitch, and zinc's runtime sweepEnabled setting
+			// (admin-flippable in the zinc UI) is the operative switch — both must
+			// be on for a sweep tick to run. Failures reading the zinc switch fail
+			// CLOSED: never sweep when the switch cannot be read. The reconcile
+			// sweep below is NOT gated and keeps running either way — in-flight
+			// Processing payouts must still settle.
+			decision, settings := c.approveSweepDecision(ctx)
+			switch decision {
+			case gateSkipConfig:
 				c.logger.Info().Ctx(ctx).Msg("Withdrawer approve sweep disabled by config, skipping")
 				continue
+			case gateSkipDisabled:
+				c.logger.Info().Ctx(ctx).Msg("Withdrawer approve sweep disabled by zinc settings, skipping")
+				continue
+			case gateSkipNotFound:
+				c.logger.Warn().Ctx(ctx).Msg("Withdrawer settings endpoint not found on zinc (old zinc), treating sweep as disabled, skipping")
+				continue
+			case gateSkipFetchError:
+				c.logger.Error().Ctx(ctx).Err(settings.err).Msg("Failed to fetch zinc withdrawal settings, skipping this approve sweep tick (fail-closed)")
+				continue
+			case gateRun:
 			}
 			c.logger.Info().Ctx(ctx).Msg("Withdrawer approve sweep starting")
 			if sweepErr := c.Sweep(ctx); sweepErr != nil {
@@ -382,6 +398,106 @@ func (c *Client) approve(ctx context.Context, id string) error {
 // reconcile calls zinc's POST /api/v1.0/Withdrawal/{id}/reconcile.
 func (c *Client) reconcile(ctx context.Context, id string) error {
 	return c.postWithdrawalAction(ctx, id, "reconcile", errNotReconcilable)
+}
+
+// gateDecision is the outcome of the approve sweep's two-gate check: run the
+// sweep, or skip it for one specific reason (each reason logs differently).
+type gateDecision int
+
+const (
+	// gateRun: both gates passed — run the approve sweep.
+	gateRun gateDecision = iota
+	// gateSkipConfig: the static config killswitch (withdrawer.approveEnable)
+	// is off; zinc settings are not even fetched.
+	gateSkipConfig
+	// gateSkipDisabled: zinc's runtime sweepEnabled setting is off (an admin
+	// has not enabled sweeping in the zinc UI).
+	gateSkipDisabled
+	// gateSkipNotFound: zinc 404'd the settings endpoint — an old zinc without
+	// runtime settings. Treated as disabled.
+	gateSkipNotFound
+	// gateSkipFetchError: the settings fetch failed transiently. Fail-closed:
+	// skip this tick rather than sweep with an unreadable switch.
+	gateSkipFetchError
+)
+
+// settingsResult is the outcome of fetching zinc's runtime withdrawal
+// settings, reduced to what the sweep gate needs.
+type settingsResult struct {
+	enabled  bool  // zinc's sweepEnabled flag (meaningful only when notFound and err are zero)
+	notFound bool  // zinc 404'd the settings endpoint (old zinc)
+	err      error // transient fetch/decode failure
+}
+
+// sweepGate is the pure two-gate decision: the static config killswitch AND
+// zinc's runtime sweepEnabled switch must both be on for the approve sweep to
+// run. Any failure to read the runtime switch fails closed (404 = disabled,
+// transient error = skip this tick).
+func sweepGate(configEnable bool, s settingsResult) gateDecision {
+	switch {
+	case !configEnable:
+		return gateSkipConfig
+	case s.err != nil:
+		return gateSkipFetchError
+	case s.notFound:
+		return gateSkipNotFound
+	case !s.enabled:
+		return gateSkipDisabled
+	default:
+		return gateRun
+	}
+}
+
+// approveSweepDecision evaluates the two-gate check for one approve tick. The
+// config killswitch is checked first so a disabled deploy never calls zinc at
+// all; only then are the runtime settings fetched.
+func (c *Client) approveSweepDecision(ctx context.Context) (gateDecision, settingsResult) {
+	if !c.config.ApproveEnable {
+		return gateSkipConfig, settingsResult{}
+	}
+	s := c.fetchSweepSettings(ctx)
+	return sweepGate(true, s), s
+}
+
+// fetchSweepSettings calls zinc's GET /api/v1.0/Withdrawal/settings/current
+// and extracts the sweepEnabled flag. Hand-rolled for the same reason as
+// postWithdrawalAction: the generated SDK in lib/zinc/main.go predates the
+// settings endpoint. It reuses the zinc client's exported Server, Doer and
+// RequestEditors so auth and otel instrumentation match the generated calls
+// exactly; replace with the generated method at the next SDK regen.
+func (c *Client) fetchSweepSettings(ctx context.Context) settingsResult {
+	url := fmt.Sprintf("%s/api/v1.0/Withdrawal/settings/current", strings.TrimSuffix(c.zinc.Server, "/"))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return settingsResult{err: err}
+	}
+	for _, editor := range c.zinc.RequestEditors {
+		if err := editor(ctx, req); err != nil {
+			return settingsResult{err: err}
+		}
+	}
+	resp, err := c.zinc.Client.Do(req)
+	if err != nil {
+		return settingsResult{err: err}
+	}
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		return settingsResult{notFound: true}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return settingsResult{err: fmt.Errorf("failed to fetch withdrawal settings: status %d: %s", resp.StatusCode, string(body))}
+	}
+	if readErr != nil {
+		return settingsResult{err: readErr}
+	}
+	var settings struct {
+		SweepEnabled bool `json:"sweepEnabled"`
+	}
+	if err := json.Unmarshal(body, &settings); err != nil {
+		return settingsResult{err: fmt.Errorf("failed to decode withdrawal settings: %w", err)}
+	}
+	return settingsResult{enabled: settings.SweepEnabled}
 }
 
 // postWithdrawalAction calls zinc's POST /api/v1.0/Withdrawal/{id}/{action}

--- a/lib/withdrawer/client_test.go
+++ b/lib/withdrawer/client_test.go
@@ -358,6 +358,102 @@ func TestReconcileSkipsBenignNotProcessingRejection(t *testing.T) {
 	}
 }
 
+// The two-gate decision: the static config killswitch AND zinc's runtime
+// sweepEnabled switch must both be on, and any failure to read the runtime
+// switch fails closed (404 = disabled, transient error = skip this tick).
+func TestSweepGateDecisionTable(t *testing.T) {
+	cases := []struct {
+		name         string
+		configEnable bool
+		settings     settingsResult
+		want         gateDecision
+	}{
+		{
+			name:         "config killswitch off skips regardless of zinc",
+			configEnable: false,
+			settings:     settingsResult{enabled: true},
+			want:         gateSkipConfig,
+		},
+		{
+			name:         "config on and zinc enabled runs the sweep",
+			configEnable: true,
+			settings:     settingsResult{enabled: true},
+			want:         gateRun,
+		},
+		{
+			name:         "config on but zinc disabled skips",
+			configEnable: true,
+			settings:     settingsResult{enabled: false},
+			want:         gateSkipDisabled,
+		},
+		{
+			name:         "settings endpoint 404 (old zinc) treated as disabled",
+			configEnable: true,
+			settings:     settingsResult{notFound: true},
+			want:         gateSkipNotFound,
+		},
+		{
+			name:         "transient fetch error fails closed and skips the tick",
+			configEnable: true,
+			settings:     settingsResult{err: context.DeadlineExceeded},
+			want:         gateSkipFetchError,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sweepGate(tc.configEnable, tc.settings); got != tc.want {
+				t.Errorf("sweepGate(%v, %+v) = %v, want %v", tc.configEnable, tc.settings, got, tc.want)
+			}
+		})
+	}
+}
+
+// fetchSweepSettings maps zinc's settings responses onto settingsResult:
+// 200 passes sweepEnabled through, 404 flags notFound (old zinc), and any
+// other failure — non-2xx status or a malformed body — surfaces as err.
+func TestFetchSweepSettingsMapsResponses(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   settingsResult
+	}{
+		{"enabled", http.StatusOK, `{"cardRefundEnabled":true,"payNowMode":"Enabled","sweepEnabled":true}`, settingsResult{enabled: true}},
+		{"disabled", http.StatusOK, `{"cardRefundEnabled":false,"payNowMode":"Disabled","sweepEnabled":false}`, settingsResult{enabled: false}},
+		{"old zinc 404", http.StatusNotFound, `not found`, settingsResult{notFound: true}},
+		{"server error", http.StatusInternalServerError, `boom`, settingsResult{err: context.DeadlineExceeded}}, // err: any non-nil
+		{"malformed body", http.StatusOK, `{"sweepEnabled":`, settingsResult{err: context.DeadlineExceeded}},    // err: any non-nil
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || r.URL.Path != "/api/v1.0/Withdrawal/settings/current" {
+					t.Errorf("unexpected zinc call: %s %s", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+			zc, err := zinc.NewClient(srv.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			l := zerolog.Nop()
+			c := &Client{zinc: zc, logger: &l}
+
+			got := c.fetchSweepSettings(context.Background())
+			if (got.err != nil) != (tc.want.err != nil) {
+				t.Fatalf("err = %v, want err? %v", got.err, tc.want.err != nil)
+			}
+			if got.enabled != tc.want.enabled || got.notFound != tc.want.notFound {
+				t.Errorf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
 // One failing reconcile must not abort the sweep: the remaining withdrawals
 // are still attempted and the tallies attribute exactly one failure — and a
 // 4xx that is NOT InvalidWithdrawalOperation stays a real failure.

--- a/system/config/model.go
+++ b/system/config/model.go
@@ -107,9 +107,12 @@ type RecovererConfig struct {
 
 // Withdrawer Config
 type WithdrawerConfig struct {
-	// ApproveEnable gates the approve sweep. When false, Pending withdrawals
-	// are never auto-approved — each pays out only when a human clicks approve
-	// in zinc — while the reconcile sweep keeps running so in-flight
+	// ApproveEnable is the deploy-level killswitch for the approve sweep.
+	// Two-gate model: this static flag AND zinc's runtime sweepEnabled setting
+	// (admin-flippable in the zinc UI) must both be on for a sweep tick to
+	// run. When false, Pending withdrawals are never auto-approved — each pays
+	// out only when a human clicks approve in zinc, regardless of the zinc
+	// setting — while the reconcile sweep keeps running so in-flight
 	// Processing payouts still settle.
 	ApproveEnable bool
 	// Cron is when Pending withdrawals are swept and approved. robfig/cron v1


### PR DESCRIPTION
## Summary

Adds a runtime gate for the withdrawer's approve sweep, driven by zinc's new admin settings endpoint (`GET /api/v1.0/Withdrawal/settings/current`).

### Two-gate model

The approve sweep now runs only when **both** gates are on:

1. **Config killswitch** — `withdrawer.approveEnable` (static, deploy-level). Now defaults to `true` in both `config/app/settings.yaml` and `infra/consumer_chart/app/settings.yaml`.
2. **Zinc UI switch** — `sweepEnabled` from zinc's runtime settings endpoint, flippable by admins from the UI. Defaults to `false` server-side, so overall behavior stays off until an admin enables it.

### Fail-closed semantics

| configEnable | zinc settings fetch | decision |
|---|---|---|
| false | (not fetched) | skip — info log "disabled by config" |
| true | 200, sweepEnabled=true | **sweep runs** |
| true | 200, sweepEnabled=false | skip — info log "disabled by zinc settings" |
| true | 404 (old zinc without the endpoint) | skip — warn log, treated as disabled |
| true | transient error / non-2xx / bad body | skip this tick — error log (never sweep when the switch can't be read) |

The **reconcile sweep is unchanged** and always runs — in-flight Processing payouts must still settle regardless of gating.

### Implementation notes

- Settings fetch is hand-rolled per the `postWithdrawalAction` precedent (generated SDK in `lib/zinc/main.go` predates the endpoint); reuses the zinc client's `Server`, `Doer` and `RequestEditors` so auth and otel match generated calls. Replace at next SDK regen.
- Gate decision extracted as a pure function (`sweepGate(configEnable, settingsResult) -> gateDecision`) and unit tested over the full decision table; the settings fetch response mapping (200/404/5xx/malformed) is also unit tested.

## Testing

- `go build ./...`, `go vet ./...` green
- `go test ./...` green (10 new gate cases: 5 decision-table + 5 fetch-mapping)
