### PR TITLE
feat: report and backfill KTMB actual costs

### DIFF
--- a/cmds/ktmb_cost_backfill.go
+++ b/cmds/ktmb_cost_backfill.go
@@ -1,0 +1,54 @@
+package cmds
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/AtomiCloud/nitroso-tin/lib/encryptor"
+	"github.com/AtomiCloud/nitroso-tin/lib/ktmb"
+	"github.com/AtomiCloud/nitroso-tin/lib/ktmbcost"
+	"github.com/AtomiCloud/nitroso-tin/lib/otelredis"
+	"github.com/AtomiCloud/nitroso-tin/lib/session"
+	"github.com/AtomiCloud/nitroso-tin/lib/zinc"
+	"github.com/urfave/cli/v2"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+func (state *State) KtmbCostBackfill(c *cli.Context) error {
+	state.Logger.Info().
+		Bool("dryRun", c.Bool("dry-run")).
+		Int("max", c.Int("max")).
+		Int("pageSize", c.Int("page-size")).
+		Msg("Starting KTMB actual-cost backfill")
+
+	ktmbConfig := state.Config.Ktmb
+	mainRedis := otelredis.New(state.Config.Cache["main"])
+	k := ktmb.New(ktmbConfig.ApiUrl, ktmbConfig.AppUrl, ktmbConfig.RequestSignature, state.Logger, ktmbConfig.Proxy, ktmb.WarmConfig{})
+	loginEncr := encryptor.NewSymEncryptor[ktmb.LoginRes](state.Config.Encryptor.Key, state.Logger)
+	s := session.New(&k, &mainRedis, state.Logger, ktmbConfig.LoginKey, loginEncr)
+
+	buyerConfig := state.Config.Buyer
+	endpoint := fmt.Sprintf("%s://%s:%s", buyerConfig.Scheme, buyerConfig.Host, buyerConfig.Port)
+	zClient, err := zinc.NewClient(endpoint,
+		zinc.WithHTTPClient(otelhttp.DefaultClient),
+		zinc.WithRequestEditorFn(state.Credential.RequestEditor()))
+	if err != nil {
+		return fmt.Errorf("create zinc client: %w", err)
+	}
+
+	client := ktmbcost.New(zClient, &k, &s, state.Logger, state.Config.Enricher.Email, state.Config.Enricher.Password, ktmbcost.Options{
+		DryRun:      c.Bool("dry-run"),
+		Max:         c.Int("max"),
+		PageSize:    c.Int("page-size"),
+		SleepBuffer: time.Duration(buyerConfig.SleepBuffer) * time.Second,
+	})
+	summary, err := client.Run(c.Context)
+	state.Logger.Info().
+		Int("fetched", summary.Fetched).
+		Int("attempted", summary.Attempted).
+		Int("updated", summary.Updated).
+		Int("failed", summary.Failed).
+		Int("dryRun", summary.DryRun).
+		Msg("KTMB actual-cost backfill finished")
+	return err
+}

--- a/lib/buyer/buyer.go
+++ b/lib/buyer/buyer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/AtomiCloud/nitroso-tin/lib/ktmb"
 	"github.com/rs/zerolog"
+	"strings"
 	"time"
 )
 
@@ -27,20 +28,28 @@ func NewBuyer(k ktmb.Ktmb, logger *zerolog.Logger, contactNumber string, sleepBu
 	}
 }
 
-func (c *Buyer) Buy(userData, bookingData string, p Passenger, direction, date, t string) ([]byte, string, string, error) {
+type PurchaseResult struct {
+	PDF          []byte
+	BookingNo    string
+	TicketNo     string
+	KtmbAmount   float32
+	KtmbCurrency string
+}
+
+func (c *Buyer) Buy(userData, bookingData string, p Passenger, direction, date, t string) (PurchaseResult, error) {
 
 	sd := time.Duration(c.sleepBuffer) * time.Second
 	c.logger.Info().Msg("Initialize booking...")
 	start, err := c.ktmb.BookStart(userData, bookingData)
 	if err != nil {
 		c.logger.Error().Err(err).Msg("Failed to start booking process")
-		return nil, "", "", err
+		return PurchaseResult{}, err
 	}
 
 	if !start.Status {
 		e := fmt.Errorf("failed to start booking process: %+v", start.Messages)
 		c.logger.Error().Err(e).Strs("errors", start.Messages).Msg("Failed to start booking process")
-		return nil, "", "", e
+		return PurchaseResult{}, e
 	}
 
 	c.logger.Info().Int("sleepDuration", c.sleepBuffer).Msg("Booking Complete. Sleeping to prevent overloading...")
@@ -51,7 +60,7 @@ func (c *Buyer) Buy(userData, bookingData string, p Passenger, direction, date, 
 		// pre-payment: no money moved yet, so a plain error (retry) is safe
 		e := fmt.Errorf("book start response carries no passengers: %+v", start.Messages)
 		c.logger.Error().Err(e).Msg("Malformed book start response")
-		return nil, "", "", e
+		return PurchaseResult{}, e
 	}
 	bd1 := start.Data.BookingData
 	ud1 := start.Data.UserData
@@ -80,18 +89,18 @@ func (c *Buyer) Buy(userData, bookingData string, p Passenger, direction, date, 
 	})
 	if err != nil {
 		c.logger.Error().Err(err).Str("date", date).Str("time", t).Str("dir", direction).Msg("Failed to set passenger")
-		return nil, "", "", err
+		return PurchaseResult{}, err
 	}
 
 	if !passenger.Status {
 		if matchesConflict(c.conflictPatterns, passenger.Messages) {
 			e := &ConflictError{Messages: passenger.Messages}
 			c.logger.Error().Err(e).Strs("errors", passenger.Messages).Str("date", date).Str("time", t).Str("dir", direction).Msg("Passenger conflict detected (duplicate passport)")
-			return nil, "", "", e
+			return PurchaseResult{}, e
 		}
 		e := fmt.Errorf("failed to set passenger: %+v", passenger.Messages)
 		c.logger.Error().Err(e).Strs("errors", passenger.Messages).Str("date", date).Str("time", t).Str("dir", direction).Msg("Failed to set passenger")
-		return nil, "", "", e
+		return PurchaseResult{}, e
 	}
 
 	c.logger.Info().Int("sleepDuration", c.sleepBuffer).Msg("Passenger Set. Sleeping to prevent overloading...")
@@ -104,17 +113,17 @@ func (c *Buyer) Buy(userData, bookingData string, p Passenger, direction, date, 
 	pay, err := c.ktmb.Pay(ud2, bd2, "KtmbEWallet", passenger.Data.PaymentAmount)
 	if err != nil {
 		c.logger.Error().Err(err).Msg("Failed to pay")
-		return nil, "", "", err
+		return PurchaseResult{}, err
 	}
 	if !pay.Status {
 		if matchesConflict(c.revertPatterns, pay.Messages) {
 			e := &RevertError{Messages: pay.Messages}
 			c.logger.Warn().Err(e).Strs("errors", pay.Messages).Str("date", date).Str("time", t).Str("dir", direction).Msg("Transient pay failure with no ticket bought (revertable)")
-			return nil, "", "", e
+			return PurchaseResult{}, e
 		}
 		e := fmt.Errorf("failed to pay: %+v", pay.Messages)
 		c.logger.Error().Err(e).Strs("errors", pay.Messages).Msg("Failed to pay")
-		return nil, "", "", e
+		return PurchaseResult{}, e
 	}
 
 	c.logger.Info().Int("sleepDuration", c.sleepBuffer).Msg("Payment Complete. Sleeping to prevent overloading...")
@@ -126,12 +135,12 @@ func (c *Buyer) Buy(userData, bookingData string, p Passenger, direction, date, 
 	complete, err := c.ktmb.Complete(ud2, bd3)
 	if err != nil {
 		c.logger.Error().Err(err).Msg("Failed to complete")
-		return nil, "", "", err
+		return PurchaseResult{}, err
 	}
 	if !complete.Status {
 		e := fmt.Errorf("failed to complete: %+v", complete.Messages)
 		c.logger.Error().Err(e).Strs("errors", complete.Messages).Msg("Failed to complete")
-		return nil, "", "", e
+		return PurchaseResult{}, e
 	}
 
 	c.logger.Info().Int("sleepDuration", c.sleepBuffer).Msg("Purchase flow completed. Sleeping to prevent overloading...")
@@ -146,7 +155,7 @@ func (c *Buyer) Buy(userData, bookingData string, p Passenger, direction, date, 
 		// the only other record and it is already gone
 		e := &PurchasedError{BookingNo: bookingNo, TicketNo: ticketNo, Cause: idErr}
 		c.logger.Error().Err(idErr).Str("bookingNo", bookingNo).Msg("Purchase succeeded but complete response is malformed, parking for recovery")
-		return nil, bookingNo, ticketNo, e
+		return PurchaseResult{}, e
 	}
 
 	ticket, err := c.ktmb.PrintTicket(complete.Data.UserData, bookingNo, ticketNo)
@@ -155,14 +164,29 @@ func (c *Buyer) Buy(userData, bookingData string, p Passenger, direction, date, 
 		// caller can recover instead of treating this as a failed buy
 		e := &PurchasedError{BookingNo: bookingNo, TicketNo: ticketNo, Cause: err}
 		c.logger.Error().Err(err).Str("bookingNo", bookingNo).Str("ticketNo", ticketNo).Msg("Purchase succeeded but failed to print ticket")
-		return nil, bookingNo, ticketNo, e
+		return PurchaseResult{}, e
 	}
 
 	// log ticket identifiers, not the passenger object — the latter carries the
 	// full name + passport number (PII) into the log stream
 	c.logger.Info().Str("bookingNo", bookingNo).Str("ticketNo", ticketNo).Str("date", date).Str("time", t).Str("dir", direction).Msg("Successfully purchased Ticket")
-	return ticket, bookingNo, ticketNo, nil
+	return PurchaseResult{
+		PDF:          ticket,
+		BookingNo:    bookingNo,
+		TicketNo:     ticketNo,
+		KtmbAmount:   passenger.Data.PaymentAmount,
+		KtmbCurrency: currencyOrDefault(passenger.Data.CurrencyCode, complete.Data.Booking.Payment.CurrencyCode, complete.Data.Booking.CurrencyCode),
+	}, nil
 
+}
+
+func currencyOrDefault(values ...string) string {
+	for _, value := range values {
+		if currency := strings.ToUpper(strings.TrimSpace(value)); currency != "" {
+			return currency
+		}
+	}
+	return "MYR"
 }
 
 // ticketIdsOf extracts the booking/ticket identifiers from a successful

--- a/lib/buyer/buyer_test.go
+++ b/lib/buyer/buyer_test.go
@@ -1,10 +1,88 @@
 package buyer
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/AtomiCloud/nitroso-tin/lib/ktmb"
+	"github.com/AtomiCloud/nitroso-tin/lib/zinc"
+	openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
+	"github.com/rs/zerolog"
 )
+
+func TestCurrencyOrDefault(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []string
+		want   string
+	}{
+		{name: "passenger response", values: []string{"myr", "SGD"}, want: "MYR"},
+		{name: "later response fallback", values: []string{"", " sgd "}, want: "SGD"},
+		{name: "KTMB eWallet default", values: []string{"", "  "}, want: "MYR"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := currencyOrDefault(tt.values...); got != tt.want {
+				t.Errorf("currencyOrDefault(%q) = %q, want %q", tt.values, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompleteOnceIncludesKtmbCostMultipartFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1.0/Booking/complete/aaaaaaaa-0000-4000-8000-000000000001" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("bookingNo"); got != "B-1" {
+			t.Errorf("bookingNo = %q, want B-1", got)
+		}
+		if got := r.URL.Query().Get("ticketNo"); got != "T-1" {
+			t.Errorf("ticketNo = %q, want T-1", got)
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Errorf("parse multipart form: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if got := r.FormValue("ktmbAmount"); got != "31.5" {
+			t.Errorf("ktmbAmount = %q, want 31.5", got)
+		}
+		if got := r.FormValue("ktmbCurrency"); got != "MYR" {
+			t.Errorf("ktmbCurrency = %q, want MYR", got)
+		}
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			t.Errorf("read file field: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		defer file.Close()
+		content, err := io.ReadAll(file)
+		if err != nil || string(content) != "ticket-pdf" {
+			t.Errorf("file content = %q, %v; want ticket-pdf", content, err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	zincClient, err := zinc.NewClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger := zerolog.Nop()
+	client := &Client{zinc: zincClient, logger: &logger}
+	var id openapi_types.UUID
+	if err := id.UnmarshalText([]byte("aaaaaaaa-0000-4000-8000-000000000001")); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.completeOnce(context.Background(), id, "B-1", "T-1", 31.5, "MYR", []byte("ticket-pdf")); err != nil {
+		t.Fatalf("completeOnce returned error: %v", err)
+	}
+}
 
 func TestTicketIdsOf(t *testing.T) {
 	wellFormed := ktmb.CompleteRes{Booking: ktmb.CompleteBookingRes{

--- a/lib/buyer/client.go
+++ b/lib/buyer/client.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"mime/multipart"
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -59,7 +60,7 @@ func retryBackoff(retries int, op func(attempt int) error) error {
 	return lastErr
 }
 
-func CreateForm(values map[string]io.Reader) (s string, reader io.Reader, err error) {
+func CreateForm(values map[string]io.Reader, fields ...map[string]string) (s string, reader io.Reader, err error) {
 	var b bytes.Buffer
 	w := multipart.NewWriter(&b)
 	for key, r := range values {
@@ -72,7 +73,16 @@ func CreateForm(values map[string]io.Reader) (s string, reader io.Reader, err er
 		}
 
 	}
-	w.Close()
+	for _, formFields := range fields {
+		for key, value := range formFields {
+			if err = w.WriteField(key, value); err != nil {
+				return
+			}
+		}
+	}
+	if err = w.Close(); err != nil {
+		return
+	}
 
 	return w.FormDataContentType(), &b, nil
 }
@@ -232,7 +242,7 @@ func (c *Client) buy(ctx context.Context, direction, date, t, userData, bookingD
 
 	// don't log the passenger object (full name + passport number are PII)
 	c.logger.Info().Str("date", date).Str("time", t).Str("dir", direction).Msg("Buying for reserved booking")
-	buy, bookingNo, ticketNo, err := c.buyer.Buy(userData, bookingData, p, direction, date, t)
+	purchase, err := c.buyer.Buy(userData, bookingData, p, direction, date, t)
 	if err != nil {
 		var conflictErr *ConflictError
 		var purchasedErr *PurchasedError
@@ -260,12 +270,12 @@ func (c *Client) buy(ctx context.Context, direction, date, t, userData, bookingD
 		}
 	}
 
-	err = c.completeWithZinc(ctx, data.Id, bookingNo, ticketNo, buy)
+	err = c.completeWithZinc(ctx, data.Id, purchase.BookingNo, purchase.TicketNo, purchase.KtmbAmount, purchase.KtmbCurrency, purchase.PDF)
 	if err != nil {
 		// the ticket is bought and paid for; losing this item would strand it —
 		// park with the ticket identifiers instead of failing the queue handler
-		c.logger.Error().Ctx(ctx).Err(err).Str("bookingNo", bookingNo).Str("ticketNo", ticketNo).Msg("Failed to report completed ticket to zinc, parking booking for recovery")
-		return c.park(ctx, data.Id, direction, date, t, p, bookingNo, ticketNo, userData, bookingData, false)
+		c.logger.Error().Ctx(ctx).Err(err).Str("bookingNo", purchase.BookingNo).Str("ticketNo", purchase.TicketNo).Msg("Failed to report completed ticket to zinc, parking booking for recovery")
+		return c.park(ctx, data.Id, direction, date, t, p, purchase.BookingNo, purchase.TicketNo, userData, bookingData, false)
 	}
 
 	return nil
@@ -273,9 +283,9 @@ func (c *Client) buy(ctx context.Context, direction, date, t, userData, bookingD
 
 // completeWithZinc reports a captured ticket to zinc, retrying with backoff:
 // the KTMB money is already spent, so this must not give up on a blip
-func (c *Client) completeWithZinc(ctx context.Context, id openapi_types.UUID, bookingNo, ticketNo string, pdf []byte) error {
+func (c *Client) completeWithZinc(ctx context.Context, id openapi_types.UUID, bookingNo, ticketNo string, ktmbAmount float32, ktmbCurrency string, pdf []byte) error {
 	return retryBackoff(c.buyerCfg.CompleteRetries, func(attempt int) error {
-		err := c.completeOnce(ctx, id, bookingNo, ticketNo, pdf)
+		err := c.completeOnce(ctx, id, bookingNo, ticketNo, ktmbAmount, ktmbCurrency, pdf)
 		if err != nil {
 			c.logger.Error().Ctx(ctx).Err(err).Int("attempt", attempt).Msg("Failed to mark booking as complete")
 		}
@@ -283,9 +293,12 @@ func (c *Client) completeWithZinc(ctx context.Context, id openapi_types.UUID, bo
 	})
 }
 
-func (c *Client) completeOnce(ctx context.Context, id openapi_types.UUID, bookingNo, ticketNo string, pdf []byte) error {
+func (c *Client) completeOnce(ctx context.Context, id openapi_types.UUID, bookingNo, ticketNo string, ktmbAmount float32, ktmbCurrency string, pdf []byte) error {
 	contentType, rr, err := CreateForm(map[string]io.Reader{
 		"file": bytes.NewReader(pdf),
+	}, map[string]string{
+		"ktmbAmount":   strconv.FormatFloat(float64(ktmbAmount), 'f', -1, 32),
+		"ktmbCurrency": ktmbCurrency,
 	})
 	if err != nil {
 		c.logger.Error().Ctx(ctx).Err(err).Msg("Failed to create form")

--- a/lib/ktmbcost/client.go
+++ b/lib/ktmbcost/client.go
@@ -1,0 +1,238 @@
+package ktmbcost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/AtomiCloud/nitroso-tin/lib/ktmb"
+	"github.com/AtomiCloud/nitroso-tin/lib/zinc"
+	openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
+	"github.com/rs/zerolog"
+)
+
+const defaultCurrency = "MYR"
+
+type zincClient interface {
+	GetApiVVersionBookingKtmbCostMissing(ctx context.Context, version string, params *zinc.GetApiVVersionBookingKtmbCostMissingParams, reqEditors ...zinc.RequestEditorFn) (*http.Response, error)
+	PostApiVVersionBookingIdKtmbCost(ctx context.Context, version string, id openapi_types.UUID, body zinc.PostApiVVersionBookingIdKtmbCostJSONBody, reqEditors ...zinc.RequestEditorFn) (*http.Response, error)
+}
+
+type ticketClient interface {
+	GetTicket(userData, bookingNo, ticketNo string) (ktmb.GenericRes[ktmb.GetTicketRes], error)
+}
+
+type sessionProvider interface {
+	Login(ctx context.Context, email, password string) (string, error)
+}
+
+type Options struct {
+	DryRun      bool
+	Max         int
+	PageSize    int
+	SleepBuffer time.Duration
+}
+
+type Summary struct {
+	Fetched   int
+	Attempted int
+	Updated   int
+	Failed    int
+	DryRun    int
+}
+
+type Client struct {
+	zinc     zincClient
+	ktmb     ticketClient
+	session  sessionProvider
+	logger   *zerolog.Logger
+	email    string
+	password string
+	options  Options
+	sleep    func(context.Context, time.Duration) error
+}
+
+func New(zincClient zincClient, ktmbClient ticketClient, session sessionProvider, logger *zerolog.Logger, email, password string, options Options) *Client {
+	return &Client{
+		zinc:     zincClient,
+		ktmb:     ktmbClient,
+		session:  session,
+		logger:   logger,
+		email:    email,
+		password: password,
+		options:  options,
+		sleep:    sleepContext,
+	}
+}
+
+func (c *Client) Run(ctx context.Context) (Summary, error) {
+	var summary Summary
+	if c.options.Max <= 0 {
+		return summary, fmt.Errorf("max must be greater than zero")
+	}
+	if c.options.PageSize <= 0 {
+		return summary, fmt.Errorf("page size must be greater than zero")
+	}
+
+	work, err := c.listMissing(ctx)
+	if err != nil {
+		return summary, err
+	}
+	summary.Fetched = len(work)
+	if len(work) == 0 {
+		c.logger.Info().Msg("No completed bookings are missing KTMB actual cost")
+		return summary, nil
+	}
+
+	userData, err := c.session.Login(ctx, c.email, c.password)
+	if err != nil {
+		return summary, fmt.Errorf("obtain KTMB session: %w", err)
+	}
+
+	for i, item := range work {
+		if i > 0 && c.options.SleepBuffer > 0 {
+			if err := c.sleep(ctx, c.options.SleepBuffer); err != nil {
+				return summary, err
+			}
+		}
+		summary.Attempted++
+		if err := c.process(ctx, userData, item); err != nil {
+			summary.Failed++
+			c.logger.Error().Err(err).
+				Str("bookingId", item.Id.String()).
+				Str("bookingNo", item.BookingNo).
+				Str("ticketNo", item.TicketNo).
+				Msg("Failed to backfill KTMB actual cost; continuing")
+			continue
+		}
+		if c.options.DryRun {
+			summary.DryRun++
+		} else {
+			summary.Updated++
+		}
+	}
+	return summary, nil
+}
+
+func (c *Client) listMissing(ctx context.Context) ([]zinc.BookingKtmbCostMissingRes, error) {
+	work := make([]zinc.BookingKtmbCostMissingRes, 0, min(c.options.Max, c.options.PageSize))
+	seen := make(map[openapi_types.UUID]struct{})
+	scanned := 0
+	for scanned < c.options.Max {
+		limit := min(c.options.PageSize, c.options.Max-scanned)
+		limit32 := int32(limit)
+		skip32 := int32(scanned)
+		resp, err := c.zinc.GetApiVVersionBookingKtmbCostMissing(ctx, "1.0", &zinc.GetApiVVersionBookingKtmbCostMissingParams{
+			Limit: &limit32,
+			Skip:  &skip32,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list bookings missing KTMB cost: %w", err)
+		}
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("read missing KTMB cost response: %w", readErr)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("list bookings missing KTMB cost: status %d: %s", resp.StatusCode, string(body))
+		}
+		var page []zinc.BookingKtmbCostMissingRes
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, fmt.Errorf("decode missing KTMB cost response: %w", err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		if len(page) > limit {
+			page = page[:limit]
+		}
+		scanned += len(page)
+		for _, item := range page {
+			if _, duplicate := seen[item.Id]; duplicate {
+				c.logger.Debug().Str("bookingId", item.Id.String()).Msg("Skipping duplicate KTMB cost work item")
+				continue
+			}
+			seen[item.Id] = struct{}{}
+			work = append(work, item)
+		}
+		if len(page) < limit {
+			break
+		}
+	}
+	return work, nil
+}
+
+func (c *Client) process(ctx context.Context, userData string, item zinc.BookingKtmbCostMissingRes) error {
+	ticket, err := c.ktmb.GetTicket(userData, item.BookingNo, item.TicketNo)
+	if err != nil {
+		return fmt.Errorf("get KTMB ticket: %w", err)
+	}
+	if !ticket.Status {
+		return fmt.Errorf("get KTMB ticket: %s", strings.Join(ticket.Messages, ", "))
+	}
+	booking, err := bookingFrom(ticket.Data, item.BookingNo)
+	if err != nil {
+		return err
+	}
+	currency := normalizeCurrency(booking.CurrencyCode)
+
+	c.logger.Info().
+		Bool("dryRun", c.options.DryRun).
+		Str("bookingId", item.Id.String()).
+		Str("bookingNo", item.BookingNo).
+		Str("ticketNo", item.TicketNo).
+		Float32("ktmbAmount", booking.TotalAmount).
+		Str("ktmbCurrency", currency).
+		Str("completedAt", item.CompletedAt).
+		Msg("Resolved KTMB actual cost")
+	if c.options.DryRun {
+		return nil
+	}
+
+	resp, err := c.zinc.PostApiVVersionBookingIdKtmbCost(ctx, "1.0", item.Id, zinc.PostApiVVersionBookingIdKtmbCostJSONBody{
+		Amount:   booking.TotalAmount,
+		Currency: currency,
+	})
+	if err != nil {
+		return fmt.Errorf("post KTMB actual cost: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("post KTMB actual cost: status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+func bookingFrom(ticket ktmb.GetTicketRes, bookingNo string) (ktmb.GetTicketBookingRes, error) {
+	for _, booking := range ticket.Bookings {
+		if booking.BookingNo == bookingNo {
+			return booking, nil
+		}
+	}
+	return ktmb.GetTicketBookingRes{}, fmt.Errorf("KTMB ticket response does not contain booking %q", bookingNo)
+}
+
+func normalizeCurrency(currency string) string {
+	currency = strings.ToUpper(strings.TrimSpace(currency))
+	if currency == "" {
+		return defaultCurrency
+	}
+	return currency
+}
+
+func sleepContext(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/lib/ktmbcost/client_test.go
+++ b/lib/ktmbcost/client_test.go
@@ -1,0 +1,302 @@
+package ktmbcost
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AtomiCloud/nitroso-tin/lib/ktmb"
+	"github.com/AtomiCloud/nitroso-tin/lib/zinc"
+	openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
+	"github.com/rs/zerolog"
+)
+
+const (
+	idA = "aaaaaaaa-0000-4000-8000-000000000001"
+	idB = "aaaaaaaa-0000-4000-8000-000000000002"
+	idC = "aaaaaaaa-0000-4000-8000-000000000003"
+	idD = "aaaaaaaa-0000-4000-8000-000000000004"
+)
+
+type recordedCost struct {
+	id   string
+	body zinc.PostApiVVersionBookingIdKtmbCostJSONBody
+}
+
+type zincStub struct {
+	t            *testing.T
+	pages        map[int][]zinc.BookingKtmbCostMissingRes
+	missing      []zinc.BookingKtmbCostMissingRes
+	dynamic      bool
+	postStatuses map[string]int
+	listSkips    []int
+	posts        []recordedCost
+}
+
+func (s *zincStub) server() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1.0/Booking/ktmb-cost/missing":
+			limit, err := strconv.Atoi(r.URL.Query().Get("Limit"))
+			if err != nil || limit <= 0 {
+				s.t.Errorf("invalid Limit %q", r.URL.Query().Get("Limit"))
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			skip, err := strconv.Atoi(r.URL.Query().Get("Skip"))
+			if err != nil {
+				s.t.Errorf("invalid Skip %q", r.URL.Query().Get("Skip"))
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			s.listSkips = append(s.listSkips, skip)
+			page := s.pages[skip]
+			if s.dynamic {
+				posted := make(map[string]struct{}, len(s.posts))
+				for _, post := range s.posts {
+					posted[post.id] = struct{}{}
+				}
+				remaining := make([]zinc.BookingKtmbCostMissingRes, 0, len(s.missing))
+				for _, item := range s.missing {
+					if _, done := posted[item.Id.String()]; !done {
+						remaining = append(remaining, item)
+					}
+				}
+				if skip < len(remaining) {
+					end := min(skip+limit, len(remaining))
+					page = remaining[skip:end]
+				} else {
+					page = nil
+				}
+			}
+			if err := json.NewEncoder(w).Encode(page); err != nil {
+				s.t.Fatal(err)
+			}
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/api/v1.0/Booking/") && strings.HasSuffix(r.URL.Path, "/ktmb-cost"):
+			id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1.0/Booking/"), "/ktmb-cost")
+			var body zinc.PostApiVVersionBookingIdKtmbCostJSONBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				s.t.Errorf("decode post body: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			s.posts = append(s.posts, recordedCost{id: id, body: body})
+			if status := s.postStatuses[id]; status != 0 {
+				w.WriteHeader(status)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			s.t.Errorf("unexpected zinc call: %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+}
+
+type fakeTickets struct {
+	results map[string]ktmb.GenericRes[ktmb.GetTicketRes]
+	errors  map[string]error
+	calls   []string
+}
+
+func (f *fakeTickets) GetTicket(_ string, bookingNo, _ string) (ktmb.GenericRes[ktmb.GetTicketRes], error) {
+	f.calls = append(f.calls, bookingNo)
+	if err := f.errors[bookingNo]; err != nil {
+		return ktmb.GenericRes[ktmb.GetTicketRes]{}, err
+	}
+	return f.results[bookingNo], nil
+}
+
+type fakeSession struct {
+	calls int
+	err   error
+}
+
+func (s *fakeSession) Login(context.Context, string, string) (string, error) {
+	s.calls++
+	return "user-data", s.err
+}
+
+func workItem(t *testing.T, id, bookingNo string) zinc.BookingKtmbCostMissingRes {
+	t.Helper()
+	var parsed openapi_types.UUID
+	if err := parsed.UnmarshalText([]byte(id)); err != nil {
+		t.Fatal(err)
+	}
+	return zinc.BookingKtmbCostMissingRes{
+		Id:          parsed,
+		BookingNo:   bookingNo,
+		TicketNo:    "T-" + bookingNo,
+		CompletedAt: "2026-07-01T00:00:00Z",
+	}
+}
+
+func ticketResult(bookingNo string, amount float32, currency string) ktmb.GenericRes[ktmb.GetTicketRes] {
+	return ktmb.GenericRes[ktmb.GetTicketRes]{
+		Status: true,
+		Data: ktmb.GetTicketRes{Bookings: []ktmb.GetTicketBookingRes{{
+			BookingNo:    bookingNo,
+			TotalAmount:  amount,
+			CurrencyCode: currency,
+		}}},
+	}
+}
+
+func testClient(t *testing.T, stub *zincStub, tickets *fakeTickets, session *fakeSession, options Options) (*Client, func()) {
+	t.Helper()
+	server := stub.server()
+	zincClient, err := zinc.NewClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger := zerolog.Nop()
+	client := New(zincClient, tickets, session, &logger, "email", "password", options)
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+	return client, server.Close
+}
+
+func TestRunPagesDedupesAndPostsExactCost(t *testing.T) {
+	items := []zinc.BookingKtmbCostMissingRes{
+		workItem(t, idA, "B-A"),
+		workItem(t, idB, "B-B"),
+		workItem(t, idC, "B-C"),
+	}
+	stub := &zincStub{t: t, pages: map[int][]zinc.BookingKtmbCostMissingRes{
+		0: {items[0], items[1]},
+		2: {items[1], items[2]},
+		4: {},
+	}}
+	tickets := &fakeTickets{results: map[string]ktmb.GenericRes[ktmb.GetTicketRes]{
+		"B-A": ticketResult("B-A", 15.5, "myr"),
+		"B-B": ticketResult("B-B", 22, ""),
+		"B-C": ticketResult("B-C", 30.25, "MYR"),
+	}}
+	client, closeServer := testClient(t, stub, tickets, &fakeSession{}, Options{Max: 10, PageSize: 2})
+	defer closeServer()
+
+	summary, err := client.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if got, want := stub.listSkips, []int{0, 2, 4}; !equalInts(got, want) {
+		t.Fatalf("list skips = %v, want %v", got, want)
+	}
+	if len(stub.posts) != 3 {
+		t.Fatalf("posts = %+v, want exactly 3 unique bookings", stub.posts)
+	}
+	if stub.posts[0].body.Amount != 15.5 || stub.posts[0].body.Currency != "MYR" {
+		t.Errorf("first cost = %+v, want 15.5 MYR", stub.posts[0].body)
+	}
+	if stub.posts[1].body.Currency != "MYR" {
+		t.Errorf("blank KTMB currency should default to MYR, got %+v", stub.posts[1].body)
+	}
+	if summary.Fetched != 3 || summary.Attempted != 3 || summary.Updated != 3 || summary.Failed != 0 {
+		t.Errorf("unexpected summary: %+v", summary)
+	}
+}
+
+func TestRunSecondPassSkipsAlreadyUpdatedWork(t *testing.T) {
+	item := workItem(t, idA, "B-A")
+	stub := &zincStub{t: t, dynamic: true, missing: []zinc.BookingKtmbCostMissingRes{item}}
+	tickets := &fakeTickets{results: map[string]ktmb.GenericRes[ktmb.GetTicketRes]{
+		"B-A": ticketResult("B-A", 10, "MYR"),
+	}}
+	session := &fakeSession{}
+	client, closeServer := testClient(t, stub, tickets, session, Options{Max: 10, PageSize: 2})
+	defer closeServer()
+
+	if _, err := client.Run(context.Background()); err != nil {
+		t.Fatalf("first Run returned error: %v", err)
+	}
+	second, err := client.Run(context.Background())
+	if err != nil {
+		t.Fatalf("second Run returned error: %v", err)
+	}
+	if len(stub.posts) != 1 || len(tickets.calls) != 1 {
+		t.Fatalf("rerun should not reprocess updated work: posts=%d KTMB calls=%d", len(stub.posts), len(tickets.calls))
+	}
+	if second.Fetched != 0 || second.Attempted != 0 || session.calls != 1 {
+		t.Errorf("empty rerun should stop before login: summary=%+v login calls=%d", second, session.calls)
+	}
+}
+
+func TestRunContinuesPastPerItemFailures(t *testing.T) {
+	items := []zinc.BookingKtmbCostMissingRes{
+		workItem(t, idA, "B-A"),
+		workItem(t, idB, "B-B"),
+		workItem(t, idC, "B-C"),
+		workItem(t, idD, "B-D"),
+	}
+	stub := &zincStub{
+		t:            t,
+		pages:        map[int][]zinc.BookingKtmbCostMissingRes{0: items},
+		postStatuses: map[string]int{idC: http.StatusInternalServerError},
+	}
+	tickets := &fakeTickets{
+		results: map[string]ktmb.GenericRes[ktmb.GetTicketRes]{
+			"B-A": ticketResult("B-A", 10, "MYR"),
+			"B-C": ticketResult("B-C", 30, "MYR"),
+			"B-D": ticketResult("B-D", 40, "MYR"),
+		},
+		errors: map[string]error{"B-B": errors.New("KTMB unavailable")},
+	}
+	client, closeServer := testClient(t, stub, tickets, &fakeSession{}, Options{Max: 10, PageSize: 10})
+	defer closeServer()
+
+	summary, err := client.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(tickets.calls) != 4 {
+		t.Errorf("KTMB calls = %v, want all four attempted", tickets.calls)
+	}
+	if len(stub.posts) != 3 || stub.posts[2].id != idD {
+		t.Errorf("zinc posts = %+v, want A, C, and D despite failures", stub.posts)
+	}
+	if summary.Attempted != 4 || summary.Updated != 2 || summary.Failed != 2 {
+		t.Errorf("unexpected summary: %+v", summary)
+	}
+}
+
+func TestRunDryRunFetchesCostsWithoutPosting(t *testing.T) {
+	items := []zinc.BookingKtmbCostMissingRes{
+		workItem(t, idA, "B-A"),
+		workItem(t, idB, "B-B"),
+	}
+	stub := &zincStub{t: t, pages: map[int][]zinc.BookingKtmbCostMissingRes{0: items, 2: {}}}
+	tickets := &fakeTickets{results: map[string]ktmb.GenericRes[ktmb.GetTicketRes]{
+		"B-A": ticketResult("B-A", 10, "MYR"),
+		"B-B": ticketResult("B-B", 20, "MYR"),
+	}}
+	client, closeServer := testClient(t, stub, tickets, &fakeSession{}, Options{DryRun: true, Max: 10, PageSize: 2})
+	defer closeServer()
+
+	summary, err := client.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(tickets.calls) != 2 || len(stub.posts) != 0 {
+		t.Fatalf("dry run should resolve both KTMB costs and post none: KTMB=%v posts=%v", tickets.calls, stub.posts)
+	}
+	if summary.DryRun != 2 || summary.Updated != 0 || summary.Failed != 0 {
+		t.Errorf("unexpected summary: %+v", summary)
+	}
+}
+
+func equalInts(left, right []int) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/lib/zinc/ktmb_cost.go
+++ b/lib/zinc/ktmb_cost.go
@@ -1,0 +1,99 @@
+package zinc
+
+// This file hand-extends the generated client for zinc's KTMB actual-cost
+// endpoints pending swagger regeneration.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
+)
+
+type BookingKtmbCostMissingRes struct {
+	Id          openapi_types.UUID `json:"id"`
+	BookingNo   string             `json:"bookingNo"`
+	TicketNo    string             `json:"ticketNo"`
+	CompletedAt string             `json:"completedAt"`
+}
+
+type GetApiVVersionBookingKtmbCostMissingParams struct {
+	Limit *int32 `form:"Limit,omitempty" json:"Limit,omitempty"`
+	Skip  *int32 `form:"Skip,omitempty" json:"Skip,omitempty"`
+}
+
+type PostApiVVersionBookingIdKtmbCostJSONBody struct {
+	Amount   float32 `json:"amount"`
+	Currency string  `json:"currency"`
+}
+
+func (c *Client) GetApiVVersionBookingKtmbCostMissing(ctx context.Context, version string, params *GetApiVVersionBookingKtmbCostMissingParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetApiVVersionBookingKtmbCostMissingRequest(c.Server, version, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostApiVVersionBookingIdKtmbCost(ctx context.Context, version string, id openapi_types.UUID, body PostApiVVersionBookingIdKtmbCostJSONBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostApiVVersionBookingIdKtmbCostRequest(c.Server, version, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func NewGetApiVVersionBookingKtmbCostMissingRequest(server, version string, params *GetApiVVersionBookingKtmbCostMissingParams) (*http.Request, error) {
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+	queryURL, err := serverURL.Parse(fmt.Sprintf("./api/v%s/Booking/ktmb-cost/missing", url.PathEscape(version)))
+	if err != nil {
+		return nil, err
+	}
+	if params != nil {
+		values := queryURL.Query()
+		if params.Limit != nil {
+			values.Set("Limit", fmt.Sprint(*params.Limit))
+		}
+		if params.Skip != nil {
+			values.Set("Skip", fmt.Sprint(*params.Skip))
+		}
+		queryURL.RawQuery = values.Encode()
+	}
+	return http.NewRequest(http.MethodGet, queryURL.String(), nil)
+}
+
+func NewPostApiVVersionBookingIdKtmbCostRequest(server, version string, id openapi_types.UUID, body PostApiVVersionBookingIdKtmbCostJSONBody) (*http.Request, error) {
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+	requestURL, err := serverURL.Parse(fmt.Sprintf("./api/v%s/Booking/%s/ktmb-cost", url.PathEscape(version), url.PathEscape(id.String())))
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(http.MethodPost, requestURL.String(), bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}

--- a/lib/zinc/main.go
+++ b/lib/zinc/main.go
@@ -457,8 +457,9 @@ type PostApiVVersionBookingCompleteIdJSONBody struct {
 // PostApiVVersionBookingCompleteIdMultipartBody defines parameters for PostApiVVersionBookingCompleteId.
 type PostApiVVersionBookingCompleteIdMultipartBody struct {
 	File *openapi_types.File `json:"file,omitempty"`
-	// KtmbAmount and KtmbCurrency are hand-added pending swagger regeneration.
-	// They report the actual KTMB eWallet charge alongside the ticket PDF.
+	// NOTE: KtmbAmount and KtmbCurrency are manually added for the KTMB
+	// actual-cost contract pending swagger regeneration. They report the exact
+	// KTMB eWallet charge alongside the ticket PDF.
 	KtmbAmount   *float32 `json:"ktmbAmount,omitempty"`
 	KtmbCurrency *string  `json:"ktmbCurrency,omitempty"`
 }
@@ -765,6 +766,12 @@ type ClientInterface interface {
 
 	// GetApiVVersionBooking request
 	GetApiVVersionBooking(ctx context.Context, version string, params *GetApiVVersionBookingParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetApiVVersionBookingKtmbCostMissing and
+	// PostApiVVersionBookingIdKtmbCost are manually added for the KTMB
+	// actual-cost contract pending swagger regeneration.
+	GetApiVVersionBookingKtmbCostMissing(ctx context.Context, version string, params *GetApiVVersionBookingKtmbCostMissingParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PostApiVVersionBookingIdKtmbCost(ctx context.Context, version string, id openapi_types.UUID, body PostApiVVersionBookingIdKtmbCostJSONBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostApiVVersionBookingBuyingId request
 	PostApiVVersionBookingBuyingId(ctx context.Context, version string, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)

--- a/lib/zinc/main.go
+++ b/lib/zinc/main.go
@@ -457,6 +457,10 @@ type PostApiVVersionBookingCompleteIdJSONBody struct {
 // PostApiVVersionBookingCompleteIdMultipartBody defines parameters for PostApiVVersionBookingCompleteId.
 type PostApiVVersionBookingCompleteIdMultipartBody struct {
 	File *openapi_types.File `json:"file,omitempty"`
+	// KtmbAmount and KtmbCurrency are hand-added pending swagger regeneration.
+	// They report the actual KTMB eWallet charge alongside the ticket PDF.
+	KtmbAmount   *float32 `json:"ktmbAmount,omitempty"`
+	KtmbCurrency *string  `json:"ktmbCurrency,omitempty"`
 }
 
 // PostApiVVersionBookingCompleteIdParams defines parameters for PostApiVVersionBookingCompleteId.

--- a/main.go
+++ b/main.go
@@ -92,6 +92,29 @@ func main() {
 		Name: "nitroso-tin",
 		Commands: []*cli.Command{
 			{
+				Name:   "ktmb-cost-backfill",
+				Action: state.KtmbCostBackfill,
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:    "dry-run",
+						Usage:   "fetch and log KTMB costs without updating zinc",
+						EnvVars: []string{"KTMB_COST_BACKFILL_DRY_RUN"},
+					},
+					&cli.IntFlag{
+						Name:    "max",
+						Value:   200,
+						Usage:   "maximum number of missing bookings to process",
+						EnvVars: []string{"KTMB_COST_BACKFILL_MAX"},
+					},
+					&cli.IntFlag{
+						Name:    "page-size",
+						Value:   50,
+						Usage:   "number of missing bookings requested per zinc page",
+						EnvVars: []string{"KTMB_COST_BACKFILL_PAGE_SIZE"},
+					},
+				},
+			},
+			{
 				Name:   "cdc",
 				Action: state.Cdc,
 			},


### PR DESCRIPTION
## Summary

- report the exact KTMB eWallet amount and currency with live booking completion multipart requests
- add hand-written zinc client support for the pending KTMB cost worklist and idempotent update endpoints
- add the bounded `ktmb-cost-backfill` command with paging, deduplication, rate limiting, failure tolerance, and dry-run support
- reuse the existing Redis-backed KTMB login session and default an absent KTMB currency code to MYR

## Validation

- `go test ./...`
- `go vet ./...`
- `nix develop .#ci --command ./scripts/ci/pre-commit.sh`

## Command

`nitroso-tin ktmb-cost-backfill [--dry-run] [--max 200] [--page-size 50]`