### PR TITLE
fix: refresh rejected KTMB backfill sessions

### DIFF
--- a/lib/ktmbcost/client.go
+++ b/lib/ktmbcost/client.go
@@ -3,6 +3,7 @@ package ktmbcost
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,6 +18,8 @@ import (
 
 const defaultCurrency = "MYR"
 
+var errInvalidSession = errors.New("KTMB session is invalid")
+
 type zincClient interface {
 	GetApiVVersionBookingKtmbCostMissing(ctx context.Context, version string, params *zinc.GetApiVVersionBookingKtmbCostMissingParams, reqEditors ...zinc.RequestEditorFn) (*http.Response, error)
 	PostApiVVersionBookingIdKtmbCost(ctx context.Context, version string, id openapi_types.UUID, body zinc.PostApiVVersionBookingIdKtmbCostJSONBody, reqEditors ...zinc.RequestEditorFn) (*http.Response, error)
@@ -28,6 +31,7 @@ type ticketClient interface {
 
 type sessionProvider interface {
 	Login(ctx context.Context, email, password string) (string, error)
+	Invalidate(ctx context.Context, userData string) error
 }
 
 type Options struct {
@@ -100,7 +104,7 @@ func (c *Client) Run(ctx context.Context) (Summary, error) {
 			}
 		}
 		summary.Attempted++
-		if err := c.process(ctx, userData, item); err != nil {
+		if err := c.processWithSessionRetry(ctx, &userData, item); err != nil {
 			summary.Failed++
 			c.logger.Error().Err(err).
 				Str("bookingId", item.Id.String()).
@@ -116,6 +120,27 @@ func (c *Client) Run(ctx context.Context) (Summary, error) {
 		}
 	}
 	return summary, nil
+}
+
+func (c *Client) processWithSessionRetry(ctx context.Context, userData *string, item zinc.BookingKtmbCostMissingRes) error {
+	err := c.process(ctx, *userData, item)
+	if !errors.Is(err, errInvalidSession) {
+		return err
+	}
+
+	c.logger.Warn().
+		Str("bookingId", item.Id.String()).
+		Str("bookingNo", item.BookingNo).
+		Msg("KTMB rejected the cached session; invalidating it and retrying once")
+	if invalidateErr := c.session.Invalidate(ctx, *userData); invalidateErr != nil {
+		return fmt.Errorf("%w; invalidate cached session: %v", err, invalidateErr)
+	}
+	refreshed, loginErr := c.session.Login(ctx, c.email, c.password)
+	if loginErr != nil {
+		return fmt.Errorf("%w; refresh session: %v", err, loginErr)
+	}
+	*userData = refreshed
+	return c.process(ctx, refreshed, item)
 }
 
 func (c *Client) listMissing(ctx context.Context) ([]zinc.BookingKtmbCostMissingRes, error) {
@@ -173,6 +198,9 @@ func (c *Client) process(ctx context.Context, userData string, item zinc.Booking
 		return fmt.Errorf("get KTMB ticket: %w", err)
 	}
 	if !ticket.Status {
+		if isInvalidSession(ticket.Messages) {
+			return fmt.Errorf("%w: %s", errInvalidSession, strings.Join(ticket.Messages, ", "))
+		}
 		return fmt.Errorf("get KTMB ticket: %s", strings.Join(ticket.Messages, ", "))
 	}
 	booking, err := bookingFrom(ticket.Data, item.BookingNo)
@@ -207,6 +235,15 @@ func (c *Client) process(ctx context.Context, userData string, item zinc.Booking
 		return fmt.Errorf("post KTMB actual cost: status %d: %s", resp.StatusCode, string(body))
 	}
 	return nil
+}
+
+func isInvalidSession(messages []string) bool {
+	for _, message := range messages {
+		if strings.Contains(strings.ToLower(message), "please login to continue") {
+			return true
+		}
+	}
+	return false
 }
 
 func bookingFrom(ticket ktmb.GetTicketRes, bookingNo string) (ktmb.GetTicketBookingRes, error) {

--- a/lib/ktmbcost/client_test.go
+++ b/lib/ktmbcost/client_test.go
@@ -100,27 +100,47 @@ func (s *zincStub) server() *httptest.Server {
 }
 
 type fakeTickets struct {
-	results map[string]ktmb.GenericRes[ktmb.GetTicketRes]
-	errors  map[string]error
-	calls   []string
+	results   map[string]ktmb.GenericRes[ktmb.GetTicketRes]
+	sequences map[string][]ktmb.GenericRes[ktmb.GetTicketRes]
+	errors    map[string]error
+	calls     []string
+	userData  []string
 }
 
-func (f *fakeTickets) GetTicket(_ string, bookingNo, _ string) (ktmb.GenericRes[ktmb.GetTicketRes], error) {
+func (f *fakeTickets) GetTicket(userData, bookingNo, _ string) (ktmb.GenericRes[ktmb.GetTicketRes], error) {
 	f.calls = append(f.calls, bookingNo)
+	f.userData = append(f.userData, userData)
 	if err := f.errors[bookingNo]; err != nil {
 		return ktmb.GenericRes[ktmb.GetTicketRes]{}, err
+	}
+	if sequence := f.sequences[bookingNo]; len(sequence) > 0 {
+		result := sequence[0]
+		f.sequences[bookingNo] = sequence[1:]
+		return result, nil
 	}
 	return f.results[bookingNo], nil
 }
 
 type fakeSession struct {
-	calls int
-	err   error
+	calls         int
+	err           error
+	tokens        []string
+	invalidations []string
+	invalidateErr error
 }
 
 func (s *fakeSession) Login(context.Context, string, string) (string, error) {
 	s.calls++
+	if len(s.tokens) > 0 {
+		index := min(s.calls-1, len(s.tokens)-1)
+		return s.tokens[index], s.err
+	}
 	return "user-data", s.err
+}
+
+func (s *fakeSession) Invalidate(_ context.Context, userData string) error {
+	s.invalidations = append(s.invalidations, userData)
+	return s.invalidateErr
 }
 
 func workItem(t *testing.T, id, bookingNo string) zinc.BookingKtmbCostMissingRes {
@@ -145,6 +165,13 @@ func ticketResult(bookingNo string, amount float32, currency string) ktmb.Generi
 			TotalAmount:  amount,
 			CurrencyCode: currency,
 		}}},
+	}
+}
+
+func invalidSessionResult() ktmb.GenericRes[ktmb.GetTicketRes] {
+	return ktmb.GenericRes[ktmb.GetTicketRes]{
+		Status:   false,
+		Messages: []string{"Please login to continue."},
 	}
 }
 
@@ -289,7 +316,77 @@ func TestRunDryRunFetchesCostsWithoutPosting(t *testing.T) {
 	}
 }
 
+func TestRunReloginsAndRetriesInvalidSessionOnce(t *testing.T) {
+	item := workItem(t, idA, "B-A")
+	stub := &zincStub{t: t, pages: map[int][]zinc.BookingKtmbCostMissingRes{0: {item}}}
+	tickets := &fakeTickets{sequences: map[string][]ktmb.GenericRes[ktmb.GetTicketRes]{
+		"B-A": {invalidSessionResult(), ticketResult("B-A", 15, "MYR")},
+	}}
+	session := &fakeSession{tokens: []string{"stale-user-data", "fresh-user-data"}}
+	client, closeServer := testClient(t, stub, tickets, session, Options{Max: 10, PageSize: 10})
+	defer closeServer()
+
+	summary, err := client.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if got, want := tickets.userData, []string{"stale-user-data", "fresh-user-data"}; !equalStrings(got, want) {
+		t.Fatalf("GetTicket userData = %v, want %v", got, want)
+	}
+	if session.calls != 2 || !equalStrings(session.invalidations, []string{"stale-user-data"}) {
+		t.Fatalf("session calls = %d, invalidations = %v; want 2 logins and stale token invalidated", session.calls, session.invalidations)
+	}
+	if summary.Attempted != 1 || summary.Updated != 1 || summary.Failed != 0 {
+		t.Errorf("unexpected summary: %+v", summary)
+	}
+}
+
+func TestRunCountsFailureWhenRetriedSessionIsStillInvalid(t *testing.T) {
+	items := []zinc.BookingKtmbCostMissingRes{
+		workItem(t, idA, "B-A"),
+		workItem(t, idB, "B-B"),
+	}
+	stub := &zincStub{t: t, pages: map[int][]zinc.BookingKtmbCostMissingRes{0: items}}
+	tickets := &fakeTickets{
+		results: map[string]ktmb.GenericRes[ktmb.GetTicketRes]{
+			"B-B": ticketResult("B-B", 20, "MYR"),
+		},
+		sequences: map[string][]ktmb.GenericRes[ktmb.GetTicketRes]{
+			"B-A": {invalidSessionResult(), invalidSessionResult()},
+		},
+	}
+	session := &fakeSession{tokens: []string{"stale-user-data", "fresh-user-data"}}
+	client, closeServer := testClient(t, stub, tickets, session, Options{Max: 10, PageSize: 10})
+	defer closeServer()
+
+	summary, err := client.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if got, want := tickets.calls, []string{"B-A", "B-A", "B-B"}; !equalStrings(got, want) {
+		t.Fatalf("GetTicket calls = %v, want exactly one retry then continue with %v", got, want)
+	}
+	if session.calls != 2 || len(session.invalidations) != 1 {
+		t.Fatalf("session calls = %d, invalidations = %v; want one refresh only", session.calls, session.invalidations)
+	}
+	if summary.Attempted != 2 || summary.Updated != 1 || summary.Failed != 1 {
+		t.Errorf("unexpected summary: %+v", summary)
+	}
+}
+
 func equalInts(left, right []int) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalStrings(left, right []string) bool {
 	if len(left) != len(right) {
 		return false
 	}

--- a/lib/session/client.go
+++ b/lib/session/client.go
@@ -6,6 +6,7 @@ import (
 	"github.com/AtomiCloud/nitroso-tin/lib/encryptor"
 	"github.com/AtomiCloud/nitroso-tin/lib/ktmb"
 	"github.com/AtomiCloud/nitroso-tin/lib/otelredis"
+	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog"
 	"strings"
 )
@@ -91,4 +92,44 @@ func (s *Session) Login(ctx context.Context, email, password string) (string, er
 
 	l.Info().Msg("Successfully save login session to cache")
 	return token, nil
+}
+
+// Invalidate removes token from the shared login cache only if it is still the
+// value stored there. The compare-and-delete protects a fresh token written by
+// another consumer between the rejected request and this invalidation.
+func (s *Session) Invalidate(ctx context.Context, token string) error {
+	l := s.logger.With().Ctx(ctx).Str("redisKey", s.key).Logger()
+
+	tokenEnc, err := s.main.Get(ctx, s.key).Result()
+	if errors.Is(err, redis.Nil) {
+		l.Info().Msg("Login session cache is already empty")
+		return nil
+	}
+	if err != nil {
+		l.Error().Err(err).Msg("Failed to read cached login session for invalidation")
+		return err
+	}
+
+	cached, err := s.encryptor.Decrypt(tokenEnc)
+	if err != nil {
+		l.Error().Err(err).Msg("Failed to decrypt cached login session for invalidation")
+		return err
+	}
+	if cached != token {
+		l.Info().Msg("Login session was already refreshed; keeping replacement token")
+		return nil
+	}
+
+	const compareAndDelete = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+end
+return 0`
+	deleted, err := s.main.Eval(ctx, compareAndDelete, []string{s.key}, tokenEnc).Int64()
+	if err != nil {
+		l.Error().Err(err).Msg("Failed to invalidate cached login session")
+		return err
+	}
+	l.Info().Bool("deleted", deleted != 0).Msg("Invalidated rejected login session")
+	return nil
 }


### PR DESCRIPTION
## Summary

- detect KTMB `Please login to continue` responses while resolving backfill items
- atomically invalidate only the rejected shared Redis session, log in again, and retry that booking once
- preserve per-item failure tolerance when refresh or the single retry still fails
- cover successful refresh/retry and exhausted-retry continuation behavior

## Root cause

`lib/session.Login` returned the encrypted token cached at `Ktmb.LoginKey` indefinitely (`SET` with a zero TTL) without validating it. Once KTMB expired that token, every backfill `GetTicket` call reused it and there was no invalidation or retry path.

## Account-scoping investigation

The multi-account pool is not used to reserve or buy tickets. It is deliberately separate from the shared login key and is only sampled by the poller for helium mobile availability streams. The enricher logs into the single configured account, persists that `userData` for the reserver, and the reserver/buyer carry it through reservation and purchase; post-purchase printing also uses the purchase-flow `userData`. Therefore historical purchases are not distributed across pool accounts and a pool fallback lookup does not belong in this repair.

## Validation

- `go test ./...`
- `go vet ./...`
- `nix develop .#ci --command ./scripts/ci/pre-commit.sh`