### PR TITLE
feat: capture and backfill KTMB termination refunds

### DIFF
--- a/cmds/ktmb_cost_backfill.go
+++ b/cmds/ktmb_cost_backfill.go
@@ -15,8 +15,21 @@ import (
 )
 
 func (state *State) KtmbCostBackfill(c *cli.Context) error {
+	status := ktmbcost.StatusCompleted
+	switch c.String("status") {
+	case "completed":
+	case "terminated":
+		status = ktmbcost.StatusTerminated
+	default:
+		return fmt.Errorf("status must be completed or terminated")
+	}
+	if c.Bool("refund") {
+		status = ktmbcost.StatusTerminated
+	}
 	state.Logger.Info().
 		Bool("dryRun", c.Bool("dry-run")).
+		Bool("refund", c.Bool("refund")).
+		Int("status", status).
 		Int("max", c.Int("max")).
 		Int("pageSize", c.Int("page-size")).
 		Msg("Starting KTMB actual-cost backfill")
@@ -38,6 +51,8 @@ func (state *State) KtmbCostBackfill(c *cli.Context) error {
 
 	client := ktmbcost.New(zClient, &k, &s, state.Logger, state.Config.Enricher.Email, state.Config.Enricher.Password, ktmbcost.Options{
 		DryRun:      c.Bool("dry-run"),
+		Refund:      c.Bool("refund"),
+		Status:      status,
 		Max:         c.Int("max"),
 		PageSize:    c.Int("page-size"),
 		SleepBuffer: time.Duration(buyerConfig.SleepBuffer) * time.Second,
@@ -49,6 +64,7 @@ func (state *State) KtmbCostBackfill(c *cli.Context) error {
 		Int("updated", summary.Updated).
 		Int("failed", summary.Failed).
 		Int("dryRun", summary.DryRun).
-		Msg("KTMB actual-cost backfill finished")
+		Bool("refund", c.Bool("refund")).
+		Msg("KTMB financial backfill finished")
 	return err
 }

--- a/cmds/terminator.go
+++ b/cmds/terminator.go
@@ -1,12 +1,16 @@
 package cmds
 
 import (
+	"fmt"
+
 	"github.com/AtomiCloud/nitroso-tin/lib/encryptor"
 	"github.com/AtomiCloud/nitroso-tin/lib/ktmb"
 	"github.com/AtomiCloud/nitroso-tin/lib/otelredis"
 	"github.com/AtomiCloud/nitroso-tin/lib/session"
 	"github.com/AtomiCloud/nitroso-tin/lib/terminator"
+	"github.com/AtomiCloud/nitroso-tin/lib/zinc"
 	"github.com/urfave/cli/v2"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 func (state *State) Terminator(c *cli.Context) error {
@@ -25,10 +29,19 @@ func (state *State) Terminator(c *cli.Context) error {
 	k := ktmb.New(ktmbConfig.ApiUrl, ktmbConfig.AppUrl, ktmbConfig.RequestSignature, state.Logger, nil, ktmb.WarmConfig{PoolSize: ktmbConfig.WarmPoolSize, IntervalMs: ktmbConfig.WarmIntervalMs, DnsRefreshMs: ktmbConfig.DnsRefreshMs})
 	s := session.New(&k, &mainRedis, state.Logger, state.Config.Ktmb.LoginKey, encr)
 
-	term := terminator.NewTerminator(k, &s, state.Logger, enricherConfig)
+	buyerConfig := state.Config.Buyer
+	endpoint := fmt.Sprintf("%s://%s:%s", buyerConfig.Scheme, buyerConfig.Host, buyerConfig.Port)
+	zClient, err := zinc.NewClient(endpoint,
+		zinc.WithHTTPClient(otelhttp.DefaultClient),
+		zinc.WithRequestEditorFn(state.Credential.RequestEditor()))
+	if err != nil {
+		return fmt.Errorf("create zinc client: %w", err)
+	}
+
+	term := terminator.NewTerminator(&k, &s, zClient, state.Logger, enricherConfig)
 	client := terminator.New(&term, &streamRedis, state.OtelConfigurator, termConfig, state.Logger, state.Psm)
 
-	err := client.Start(ctx)
+	err = client.Start(ctx)
 	if err != nil {
 		state.Logger.Error().Err(err).Msg("Terminator failed")
 		return err

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.22.0
 	go.opentelemetry.io/otel/trace v1.22.0
 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
-	golang.org/x/net v0.20.0
 	k8s.io/api v0.29.1
 	k8s.io/apimachinery v0.29.1
 	k8s.io/client-go v0.29.1
@@ -137,6 +136,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/arch v0.7.0 // indirect
 	golang.org/x/crypto v0.18.0 // indirect
+	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/oauth2 v0.16.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/term v0.16.0 // indirect

--- a/lib/ktmb/ktmb.go
+++ b/lib/ktmb/ktmb.go
@@ -2,6 +2,7 @@ package ktmb
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/rs/zerolog"
@@ -307,6 +308,27 @@ func (k *Ktmb) GetTicket(userData, bookingNo, ticketNo string) (GenericRes[GetTi
 	if err != nil {
 		k.logger.Error().Err(err).Msg("Failed to print ticket")
 		return GenericRes[GetTicketRes]{}, err
+	}
+	return r, nil
+}
+
+// GetTicketRaw preserves KTMB fields that have not yet been modeled. It is
+// used by the refund backfill probe to inspect already-refunded tickets without
+// silently discarding potential refund metadata during JSON decoding.
+func (k *Ktmb) GetTicketRaw(userData, bookingNo, ticketNo string) (GenericRes[json.RawMessage], error) {
+	client := NewHttp[GetTicketReq, GenericRes[json.RawMessage]](k.NewApi())
+	req := GetTicketReq{
+		BookingNo: bookingNo,
+		Tickets: []GetTicketTicketReq{{
+			TicketNo: ticketNo,
+		}},
+	}
+	r, err := client.SendWith("POST", "v1/booking/PrintTicket", req, appHost, map[string]string{
+		"userData": userData,
+	})
+	if err != nil {
+		k.logger.Error().Err(err).Msg("Failed to get raw ticket response")
+		return GenericRes[json.RawMessage]{}, err
 	}
 	return r, nil
 }

--- a/lib/ktmbcost/client.go
+++ b/lib/ktmbcost/client.go
@@ -19,14 +19,24 @@ import (
 const defaultCurrency = "MYR"
 
 var errInvalidSession = errors.New("KTMB session is invalid")
+var errRefundAmountUnavailable = errors.New("KTMB exposes no exact refunded amount")
+
+const (
+	StatusCompleted  = 2
+	StatusTerminated = 5
+)
 
 type zincClient interface {
 	GetApiVVersionBookingKtmbCostMissing(ctx context.Context, version string, params *zinc.GetApiVVersionBookingKtmbCostMissingParams, reqEditors ...zinc.RequestEditorFn) (*http.Response, error)
 	PostApiVVersionBookingIdKtmbCost(ctx context.Context, version string, id openapi_types.UUID, body zinc.PostApiVVersionBookingIdKtmbCostJSONBody, reqEditors ...zinc.RequestEditorFn) (*http.Response, error)
+	GetApiVVersionBookingKtmbRefundMissing(ctx context.Context, version string, params *zinc.GetApiVVersionBookingKtmbRefundMissingParams, reqEditors ...zinc.RequestEditorFn) (*http.Response, error)
+	PostApiVVersionBookingIdKtmbRefund(ctx context.Context, version string, id openapi_types.UUID, body zinc.PostApiVVersionBookingIdKtmbRefundJSONBody, reqEditors ...zinc.RequestEditorFn) (*http.Response, error)
 }
 
 type ticketClient interface {
 	GetTicket(userData, bookingNo, ticketNo string) (ktmb.GenericRes[ktmb.GetTicketRes], error)
+	GetTicketRaw(userData, bookingNo, ticketNo string) (ktmb.GenericRes[json.RawMessage], error)
+	GetRefundPolicy(userData, bookingData, ticketData string) (ktmb.GenericRes[ktmb.RefundPolicyRes], error)
 }
 
 type sessionProvider interface {
@@ -36,6 +46,8 @@ type sessionProvider interface {
 
 type Options struct {
 	DryRun      bool
+	Refund      bool
+	Status      int
 	Max         int
 	PageSize    int
 	SleepBuffer time.Duration
@@ -50,14 +62,15 @@ type Summary struct {
 }
 
 type Client struct {
-	zinc     zincClient
-	ktmb     ticketClient
-	session  sessionProvider
-	logger   *zerolog.Logger
-	email    string
-	password string
-	options  Options
-	sleep    func(context.Context, time.Duration) error
+	zinc      zincClient
+	ktmb      ticketClient
+	session   sessionProvider
+	logger    *zerolog.Logger
+	email     string
+	password  string
+	options   Options
+	sleep     func(context.Context, time.Duration) error
+	rawDumped bool
 }
 
 func New(zincClient zincClient, ktmbClient ticketClient, session sessionProvider, logger *zerolog.Logger, email, password string, options Options) *Client {
@@ -81,6 +94,12 @@ func (c *Client) Run(ctx context.Context) (Summary, error) {
 	if c.options.PageSize <= 0 {
 		return summary, fmt.Errorf("page size must be greater than zero")
 	}
+	if c.options.Status == 0 {
+		c.options.Status = StatusCompleted
+	}
+	if c.options.Status != StatusCompleted && c.options.Status != StatusTerminated {
+		return summary, fmt.Errorf("status must be %d (completed) or %d (terminated)", StatusCompleted, StatusTerminated)
+	}
 
 	work, err := c.listMissing(ctx)
 	if err != nil {
@@ -88,7 +107,11 @@ func (c *Client) Run(ctx context.Context) (Summary, error) {
 	}
 	summary.Fetched = len(work)
 	if len(work) == 0 {
-		c.logger.Info().Msg("No completed bookings are missing KTMB actual cost")
+		if c.options.Refund {
+			c.logger.Info().Msg("No terminated bookings are missing KTMB refund capture")
+		} else {
+			c.logger.Info().Int("status", c.options.Status).Msg("No bookings are missing KTMB actual cost")
+		}
 		return summary, nil
 	}
 
@@ -110,7 +133,8 @@ func (c *Client) Run(ctx context.Context) (Summary, error) {
 				Str("bookingId", item.Id.String()).
 				Str("bookingNo", item.BookingNo).
 				Str("ticketNo", item.TicketNo).
-				Msg("Failed to backfill KTMB actual cost; continuing")
+				Bool("refund", c.options.Refund).
+				Msg("Failed to backfill KTMB financial data; continuing")
 			continue
 		}
 		if c.options.DryRun {
@@ -144,6 +168,9 @@ func (c *Client) processWithSessionRetry(ctx context.Context, userData *string, 
 }
 
 func (c *Client) listMissing(ctx context.Context) ([]zinc.BookingKtmbCostMissingRes, error) {
+	if c.options.Refund {
+		return c.listMissingRefunds(ctx)
+	}
 	work := make([]zinc.BookingKtmbCostMissingRes, 0, min(c.options.Max, c.options.PageSize))
 	seen := make(map[openapi_types.UUID]struct{})
 	scanned := 0
@@ -152,8 +179,9 @@ func (c *Client) listMissing(ctx context.Context) ([]zinc.BookingKtmbCostMissing
 		limit32 := int32(limit)
 		skip32 := int32(scanned)
 		resp, err := c.zinc.GetApiVVersionBookingKtmbCostMissing(ctx, "1.0", &zinc.GetApiVVersionBookingKtmbCostMissingParams{
-			Limit: &limit32,
-			Skip:  &skip32,
+			Limit:  &limit32,
+			Skip:   &skip32,
+			Status: &c.options.Status,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("list bookings missing KTMB cost: %w", err)
@@ -192,7 +220,34 @@ func (c *Client) listMissing(ctx context.Context) ([]zinc.BookingKtmbCostMissing
 	return work, nil
 }
 
+func (c *Client) listMissingRefunds(ctx context.Context) ([]zinc.BookingKtmbCostMissingRes, error) {
+	limit := int32(c.options.Max)
+	resp, err := c.zinc.GetApiVVersionBookingKtmbRefundMissing(ctx, "1.0", &zinc.GetApiVVersionBookingKtmbRefundMissingParams{Limit: &limit})
+	if err != nil {
+		return nil, fmt.Errorf("list bookings missing KTMB refund: %w", err)
+	}
+	body, readErr := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if readErr != nil {
+		return nil, fmt.Errorf("read missing KTMB refund response: %w", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("list bookings missing KTMB refund: status %d: %s", resp.StatusCode, string(body))
+	}
+	var work []zinc.BookingKtmbCostMissingRes
+	if err := json.Unmarshal(body, &work); err != nil {
+		return nil, fmt.Errorf("decode missing KTMB refund response: %w", err)
+	}
+	if len(work) > c.options.Max {
+		work = work[:c.options.Max]
+	}
+	return work, nil
+}
+
 func (c *Client) process(ctx context.Context, userData string, item zinc.BookingKtmbCostMissingRes) error {
+	if c.options.Refund {
+		return c.processRefund(ctx, userData, item)
+	}
 	ticket, err := c.ktmb.GetTicket(userData, item.BookingNo, item.TicketNo)
 	if err != nil {
 		return fmt.Errorf("get KTMB ticket: %w", err)
@@ -206,6 +261,9 @@ func (c *Client) process(ctx context.Context, userData string, item zinc.Booking
 	booking, err := bookingFrom(ticket.Data, item.BookingNo)
 	if err != nil {
 		return err
+	}
+	if booking.TotalAmount <= 0 {
+		return fmt.Errorf("KTMB ticket response for booking %q has no usable purchase amount (totalAmount=%v)", item.BookingNo, booking.TotalAmount)
 	}
 	currency := normalizeCurrency(booking.CurrencyCode)
 
@@ -237,6 +295,201 @@ func (c *Client) process(ctx context.Context, userData string, item zinc.Booking
 	return nil
 }
 
+func (c *Client) processRefund(ctx context.Context, userData string, item zinc.BookingKtmbCostMissingRes) error {
+	rawTicket, err := c.ktmb.GetTicketRaw(userData, item.BookingNo, item.TicketNo)
+	if err != nil {
+		return fmt.Errorf("get raw KTMB ticket: %w", err)
+	}
+	if !rawTicket.Status {
+		if isInvalidSession(rawTicket.Messages) {
+			return fmt.Errorf("%w: %s", errInvalidSession, strings.Join(rawTicket.Messages, ", "))
+		}
+		return fmt.Errorf("get raw KTMB ticket: %s", strings.Join(rawTicket.Messages, ", "))
+	}
+	if c.options.DryRun && !c.rawDumped {
+		encoded, marshalErr := json.Marshal(rawTicket)
+		if marshalErr == nil {
+			c.logger.Debug().RawJSON("ktmbResponse", encoded).
+				Str("bookingId", item.Id.String()).
+				Str("bookingNo", item.BookingNo).
+				Msg("Raw KTMB GetTicket response for refund probe")
+		}
+		c.rawDumped = true
+	}
+
+	amount, currency, rawFound := refundFromRaw(rawTicket.Data, item.TicketNo)
+	var typed ktmb.GetTicketRes
+	if err := json.Unmarshal(rawTicket.Data, &typed); err != nil {
+		return fmt.Errorf("decode raw KTMB ticket data: %w", err)
+	}
+	booking, bookingErr := bookingFrom(typed, item.BookingNo)
+	if bookingErr != nil {
+		if !rawFound {
+			return fmt.Errorf("%w; cannot probe refund policy: %v", errRefundAmountUnavailable, bookingErr)
+		}
+		c.logger.Warn().Err(bookingErr).Str("bookingNo", item.BookingNo).Msg("Could not probe KTMB refund policy; using exact refund field from GetTicket")
+	} else {
+		ticketData, ticketErr := ticketDataFrom(booking, item.TicketNo)
+		if ticketErr != nil {
+			if !rawFound {
+				return fmt.Errorf("%w; cannot probe refund policy: %v", errRefundAmountUnavailable, ticketErr)
+			}
+			c.logger.Warn().Err(ticketErr).Str("bookingNo", item.BookingNo).Msg("Could not probe KTMB refund policy; using exact refund field from GetTicket")
+		} else {
+			policy, policyErr := c.ktmb.GetRefundPolicy(userData, booking.BookingData, ticketData)
+			if policyErr != nil {
+				c.logger.Warn().Err(policyErr).Str("bookingNo", item.BookingNo).Msg("KTMB refund-policy probe failed")
+			} else if !policy.Status {
+				if isInvalidSession(policy.Messages) {
+					return fmt.Errorf("%w: %s", errInvalidSession, strings.Join(policy.Messages, ", "))
+				}
+				c.logger.Debug().Strs("messages", policy.Messages).Str("bookingNo", item.BookingNo).Msg("KTMB refund-policy probe rejected the already-refunded ticket")
+			} else if policyAmount, policyCurrency, ok := refundFromPolicy(policy.Data, item.TicketNo); ok {
+				amount, currency, rawFound = policyAmount, policyCurrency, true
+			}
+		}
+	}
+	if !rawFound {
+		return fmt.Errorf("%w for booking %q ticket %q; leaving zinc record missing", errRefundAmountUnavailable, item.BookingNo, item.TicketNo)
+	}
+	currency = normalizeCurrency(currency, booking.CurrencyCode)
+	c.logger.Info().
+		Bool("dryRun", c.options.DryRun).
+		Str("bookingId", item.Id.String()).
+		Str("bookingNo", item.BookingNo).
+		Str("ticketNo", item.TicketNo).
+		Float32("refundAmount", amount).
+		Str("refundCurrency", currency).
+		Msg("Resolved exact KTMB refund")
+	if c.options.DryRun {
+		return nil
+	}
+	resp, err := c.zinc.PostApiVVersionBookingIdKtmbRefund(ctx, "1.0", item.Id, zinc.PostApiVVersionBookingIdKtmbRefundJSONBody{
+		RefundAmount:   amount,
+		RefundCurrency: currency,
+	})
+	if err != nil {
+		return fmt.Errorf("post KTMB refund: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("post KTMB refund: status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+func ticketDataFrom(booking ktmb.GetTicketBookingRes, ticketNo string) (string, error) {
+	for _, trip := range booking.Trips {
+		for _, ticket := range trip.Tickets {
+			if ticket.TicketNo == ticketNo && ticket.TicketData != "" {
+				return ticket.TicketData, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("KTMB ticket response does not contain ticket data for %q", ticketNo)
+}
+
+func refundFromPolicy(policy ktmb.RefundPolicyRes, ticketNo string) (float32, string, bool) {
+	for _, trip := range policy.Trips {
+		for _, ticket := range trip.Tickets {
+			if ticket.TicketNo == ticketNo && ticket.RefundAmount > 0 {
+				return ticket.RefundAmount, normalizeCurrency(ticket.CurrencyCode, policy.CurrencyCode), true
+			}
+		}
+	}
+	if policy.TotalRefundAmount > 0 {
+		return policy.TotalRefundAmount, normalizeCurrency(policy.CurrencyCode), true
+	}
+	return 0, "", false
+}
+
+func refundFromRaw(raw json.RawMessage, ticketNo string) (float32, string, bool) {
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.UseNumber()
+	var root any
+	if err := decoder.Decode(&root); err != nil {
+		return 0, "", false
+	}
+	if amount, currency, ok := refundInTicketNode(root, ticketNo); ok {
+		return amount, currency, true
+	}
+	return exactRefundInNode(root)
+}
+
+func refundInTicketNode(node any, ticketNo string) (float32, string, bool) {
+	switch value := node.(type) {
+	case map[string]any:
+		if stringField(value, "ticketNo") == ticketNo {
+			if amount, currency, ok := exactRefundInMap(value); ok {
+				return amount, currency, true
+			}
+		}
+		for _, child := range value {
+			if amount, currency, ok := refundInTicketNode(child, ticketNo); ok {
+				return amount, currency, true
+			}
+		}
+	case []any:
+		for _, child := range value {
+			if amount, currency, ok := refundInTicketNode(child, ticketNo); ok {
+				return amount, currency, true
+			}
+		}
+	}
+	return 0, "", false
+}
+
+func exactRefundInNode(node any) (float32, string, bool) {
+	switch value := node.(type) {
+	case map[string]any:
+		if amount, currency, ok := exactRefundInMap(value); ok {
+			return amount, currency, true
+		}
+		for _, child := range value {
+			if amount, currency, ok := exactRefundInNode(child); ok {
+				return amount, currency, true
+			}
+		}
+	case []any:
+		for _, child := range value {
+			if amount, currency, ok := exactRefundInNode(child); ok {
+				return amount, currency, true
+			}
+		}
+	}
+	return 0, "", false
+}
+
+func exactRefundInMap(value map[string]any) (float32, string, bool) {
+	for _, key := range []string{"refundAmount", "refundedAmount", "totalRefundAmount"} {
+		if amount, ok := numberField(value, key); ok && amount > 0 {
+			return amount, normalizeCurrency(stringField(value, "refundCurrency"), stringField(value, "currencyCode")), true
+		}
+	}
+	return 0, "", false
+}
+
+func numberField(value map[string]any, key string) (float32, bool) {
+	raw, ok := value[key]
+	if !ok {
+		return 0, false
+	}
+	switch number := raw.(type) {
+	case json.Number:
+		parsed, err := number.Float64()
+		return float32(parsed), err == nil
+	case float64:
+		return float32(number), true
+	}
+	return 0, false
+}
+
+func stringField(value map[string]any, key string) string {
+	result, _ := value[key].(string)
+	return result
+}
+
 func isInvalidSession(messages []string) bool {
 	for _, message := range messages {
 		if strings.Contains(strings.ToLower(message), "please login to continue") {
@@ -255,12 +508,14 @@ func bookingFrom(ticket ktmb.GetTicketRes, bookingNo string) (ktmb.GetTicketBook
 	return ktmb.GetTicketBookingRes{}, fmt.Errorf("KTMB ticket response does not contain booking %q", bookingNo)
 }
 
-func normalizeCurrency(currency string) string {
-	currency = strings.ToUpper(strings.TrimSpace(currency))
-	if currency == "" {
-		return defaultCurrency
+func normalizeCurrency(currencies ...string) string {
+	for _, currency := range currencies {
+		currency = strings.ToUpper(strings.TrimSpace(currency))
+		if currency != "" {
+			return currency
+		}
 	}
-	return currency
+	return defaultCurrency
 }
 
 func sleepContext(ctx context.Context, duration time.Duration) error {

--- a/lib/ktmbcost/client_test.go
+++ b/lib/ktmbcost/client_test.go
@@ -29,6 +29,11 @@ type recordedCost struct {
 	body zinc.PostApiVVersionBookingIdKtmbCostJSONBody
 }
 
+type recordedRefund struct {
+	id   string
+	body zinc.PostApiVVersionBookingIdKtmbRefundJSONBody
+}
+
 type zincStub struct {
 	t            *testing.T
 	pages        map[int][]zinc.BookingKtmbCostMissingRes
@@ -36,13 +41,22 @@ type zincStub struct {
 	dynamic      bool
 	postStatuses map[string]int
 	listSkips    []int
+	listStatuses []int
 	posts        []recordedCost
+	refunds      []recordedRefund
 }
 
 func (s *zincStub) server() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1.0/Booking/ktmb-cost/missing":
+			status, err := strconv.Atoi(r.URL.Query().Get("Status"))
+			if err != nil {
+				s.t.Errorf("invalid Status %q", r.URL.Query().Get("Status"))
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			s.listStatuses = append(s.listStatuses, status)
 			limit, err := strconv.Atoi(r.URL.Query().Get("Limit"))
 			if err != nil || limit <= 0 {
 				s.t.Errorf("invalid Limit %q", r.URL.Query().Get("Limit"))
@@ -78,6 +92,20 @@ func (s *zincStub) server() *httptest.Server {
 			if err := json.NewEncoder(w).Encode(page); err != nil {
 				s.t.Fatal(err)
 			}
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1.0/Booking/ktmb-refund/missing":
+			limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
+			if err != nil || limit <= 0 {
+				s.t.Errorf("invalid refund limit %q", r.URL.Query().Get("limit"))
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			page := s.missing
+			if len(page) > limit {
+				page = page[:limit]
+			}
+			if err := json.NewEncoder(w).Encode(page); err != nil {
+				s.t.Fatal(err)
+			}
 		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/api/v1.0/Booking/") && strings.HasSuffix(r.URL.Path, "/ktmb-cost"):
 			id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1.0/Booking/"), "/ktmb-cost")
 			var body zinc.PostApiVVersionBookingIdKtmbCostJSONBody
@@ -92,6 +120,20 @@ func (s *zincStub) server() *httptest.Server {
 				return
 			}
 			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/api/v1.0/Booking/") && strings.HasSuffix(r.URL.Path, "/ktmb-refund"):
+			id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1.0/Booking/"), "/ktmb-refund")
+			var body zinc.PostApiVVersionBookingIdKtmbRefundJSONBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				s.t.Errorf("decode refund body: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			s.refunds = append(s.refunds, recordedRefund{id: id, body: body})
+			if status := s.postStatuses[id]; status != 0 {
+				w.WriteHeader(status)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
 		default:
 			s.t.Errorf("unexpected zinc call: %s %s", r.Method, r.URL.String())
 			w.WriteHeader(http.StatusInternalServerError)
@@ -100,11 +142,14 @@ func (s *zincStub) server() *httptest.Server {
 }
 
 type fakeTickets struct {
-	results   map[string]ktmb.GenericRes[ktmb.GetTicketRes]
-	sequences map[string][]ktmb.GenericRes[ktmb.GetTicketRes]
-	errors    map[string]error
-	calls     []string
-	userData  []string
+	results     map[string]ktmb.GenericRes[ktmb.GetTicketRes]
+	sequences   map[string][]ktmb.GenericRes[ktmb.GetTicketRes]
+	errors      map[string]error
+	calls       []string
+	userData    []string
+	rawResults  map[string]ktmb.GenericRes[json.RawMessage]
+	policies    map[string]ktmb.GenericRes[ktmb.RefundPolicyRes]
+	policyCalls []string
 }
 
 func (f *fakeTickets) GetTicket(userData, bookingNo, _ string) (ktmb.GenericRes[ktmb.GetTicketRes], error) {
@@ -119,6 +164,20 @@ func (f *fakeTickets) GetTicket(userData, bookingNo, _ string) (ktmb.GenericRes[
 		return result, nil
 	}
 	return f.results[bookingNo], nil
+}
+
+func (f *fakeTickets) GetTicketRaw(userData, bookingNo, _ string) (ktmb.GenericRes[json.RawMessage], error) {
+	f.calls = append(f.calls, bookingNo)
+	f.userData = append(f.userData, userData)
+	if err := f.errors[bookingNo]; err != nil {
+		return ktmb.GenericRes[json.RawMessage]{}, err
+	}
+	return f.rawResults[bookingNo], nil
+}
+
+func (f *fakeTickets) GetRefundPolicy(_ string, bookingData, _ string) (ktmb.GenericRes[ktmb.RefundPolicyRes], error) {
+	f.policyCalls = append(f.policyCalls, bookingData)
+	return f.policies[bookingData], nil
 }
 
 type fakeSession struct {
@@ -173,6 +232,28 @@ func invalidSessionResult() ktmb.GenericRes[ktmb.GetTicketRes] {
 		Status:   false,
 		Messages: []string{"Please login to continue."},
 	}
+}
+
+func rawTicketResult(t *testing.T, bookingNo string, refundAmount *float32) ktmb.GenericRes[json.RawMessage] {
+	t.Helper()
+	ticket := map[string]any{
+		"ticketNo":   "T-" + bookingNo,
+		"ticketData": "ticket-data-" + bookingNo,
+	}
+	if refundAmount != nil {
+		ticket["refundAmount"] = *refundAmount
+		ticket["refundCurrency"] = "myr"
+	}
+	data, err := json.Marshal(map[string]any{"bookings": []any{map[string]any{
+		"bookingNo":    bookingNo,
+		"bookingData":  "booking-data-" + bookingNo,
+		"currencyCode": "MYR",
+		"trips":        []any{map[string]any{"tickets": []any{ticket}}},
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ktmb.GenericRes[json.RawMessage]{Status: true, Data: data}
 }
 
 func testClient(t *testing.T, stub *zincStub, tickets *fakeTickets, session *fakeSession, options Options) (*Client, func()) {
@@ -371,6 +452,104 @@ func TestRunCountsFailureWhenRetriedSessionIsStillInvalid(t *testing.T) {
 	}
 	if summary.Attempted != 2 || summary.Updated != 1 || summary.Failed != 1 {
 		t.Errorf("unexpected summary: %+v", summary)
+	}
+}
+
+func TestRunPassesTerminatedStatusAndRejectsMissingPurchaseAmount(t *testing.T) {
+	item := workItem(t, idA, "B-A")
+	stub := &zincStub{t: t, pages: map[int][]zinc.BookingKtmbCostMissingRes{0: {item}}}
+	tickets := &fakeTickets{results: map[string]ktmb.GenericRes[ktmb.GetTicketRes]{
+		"B-A": ticketResult("B-A", 0, "MYR"),
+	}}
+	client, closeServer := testClient(t, stub, tickets, &fakeSession{}, Options{Status: StatusTerminated, Max: 10, PageSize: 10})
+	defer closeServer()
+
+	summary, err := client.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if !equalInts(stub.listStatuses, []int{StatusTerminated}) {
+		t.Fatalf("Status queries = %v, want terminated (%d)", stub.listStatuses, StatusTerminated)
+	}
+	if summary.Failed != 1 || summary.Updated != 0 || len(stub.posts) != 0 {
+		t.Fatalf("missing cancelled-ticket amount must fail without posting: summary=%+v posts=%v", summary, stub.posts)
+	}
+}
+
+func TestRunRefundBackfillUsesExactPolicyAmount(t *testing.T) {
+	item := workItem(t, idA, "B-A")
+	stub := &zincStub{t: t, missing: []zinc.BookingKtmbCostMissingRes{item}}
+	tickets := &fakeTickets{
+		rawResults: map[string]ktmb.GenericRes[json.RawMessage]{"B-A": rawTicketResult(t, "B-A", nil)},
+		policies: map[string]ktmb.GenericRes[ktmb.RefundPolicyRes]{
+			"booking-data-B-A": {
+				Status: true,
+				Data: ktmb.RefundPolicyRes{
+					CurrencyCode: "MYR",
+					Trips: []ktmb.RefundPolicyTripRes{{
+						Tickets: []ktmb.RefundPolicyTripTicketRes{{
+							TicketNo: "T-B-A", RefundAmount: 7.5, CurrencyCode: "myr",
+						}},
+					}},
+				},
+			},
+		},
+	}
+	client, closeServer := testClient(t, stub, tickets, &fakeSession{}, Options{Refund: true, Status: StatusTerminated, Max: 10, PageSize: 10})
+	defer closeServer()
+
+	summary, err := client.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(stub.refunds) != 1 || stub.refunds[0].body.RefundAmount != 7.5 || stub.refunds[0].body.RefundCurrency != "MYR" {
+		t.Fatalf("refund posts = %+v, want exact 7.5 MYR", stub.refunds)
+	}
+	if !equalStrings(tickets.policyCalls, []string{"booking-data-B-A"}) || summary.Updated != 1 || summary.Failed != 0 {
+		t.Fatalf("policy calls=%v summary=%+v", tickets.policyCalls, summary)
+	}
+}
+
+func TestRunRefundDryRunFindsRawAmountAndDoesNotPost(t *testing.T) {
+	item := workItem(t, idA, "B-A")
+	amount := float32(6.25)
+	stub := &zincStub{t: t, missing: []zinc.BookingKtmbCostMissingRes{item}}
+	tickets := &fakeTickets{
+		rawResults: map[string]ktmb.GenericRes[json.RawMessage]{"B-A": rawTicketResult(t, "B-A", &amount)},
+		policies: map[string]ktmb.GenericRes[ktmb.RefundPolicyRes]{
+			"booking-data-B-A": {Status: false, Messages: []string{"Refund is no longer allowed"}},
+		},
+	}
+	client, closeServer := testClient(t, stub, tickets, &fakeSession{}, Options{DryRun: true, Refund: true, Status: StatusTerminated, Max: 10, PageSize: 10})
+	defer closeServer()
+
+	summary, err := client.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(stub.refunds) != 0 || summary.DryRun != 1 || summary.Failed != 0 {
+		t.Fatalf("dry-run refund summary=%+v posts=%+v", summary, stub.refunds)
+	}
+}
+
+func TestRunRefundLeavesMissingWhenKTMBHasNoExactAmount(t *testing.T) {
+	item := workItem(t, idA, "B-A")
+	stub := &zincStub{t: t, missing: []zinc.BookingKtmbCostMissingRes{item}}
+	tickets := &fakeTickets{
+		rawResults: map[string]ktmb.GenericRes[json.RawMessage]{"B-A": rawTicketResult(t, "B-A", nil)},
+		policies: map[string]ktmb.GenericRes[ktmb.RefundPolicyRes]{
+			"booking-data-B-A": {Status: false, Messages: []string{"Refund is no longer allowed"}},
+		},
+	}
+	client, closeServer := testClient(t, stub, tickets, &fakeSession{}, Options{Refund: true, Status: StatusTerminated, Max: 10, PageSize: 10})
+	defer closeServer()
+
+	summary, err := client.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if len(stub.refunds) != 0 || summary.Failed != 1 || summary.Updated != 0 {
+		t.Fatalf("unknown refund must remain missing: summary=%+v posts=%+v", summary, stub.refunds)
 	}
 }
 

--- a/lib/terminator/client.go
+++ b/lib/terminator/client.go
@@ -90,7 +90,7 @@ func (c *Client) loop(ctx context.Context) (bool, error) {
 		}
 
 		c.logger.Info().Any("termination", termMessage).Ctx(ctx).Msg("Termination message")
-		er := c.terminator.Terminate(termMessage)
+		er := c.terminator.Terminate(ctx, termMessage)
 		if er != nil {
 			c.logger.Error().Err(er).Msg("Failed to terminate")
 			return er

--- a/lib/terminator/termination.go
+++ b/lib/terminator/termination.go
@@ -1,6 +1,9 @@
 package terminator
 
+import openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
+
 type BookingTermination struct {
-	BookingNo string
-	TicketNo  string
+	Id        openapi_types.UUID `json:"id"`
+	BookingNo string             `json:"bookingNo"`
+	TicketNo  string             `json:"ticketNo"`
 }

--- a/lib/terminator/terminator.go
+++ b/lib/terminator/terminator.go
@@ -1,26 +1,47 @@
 package terminator
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
 	"github.com/AtomiCloud/nitroso-tin/lib/ktmb"
-	"github.com/AtomiCloud/nitroso-tin/lib/session"
+	"github.com/AtomiCloud/nitroso-tin/lib/zinc"
 	"github.com/AtomiCloud/nitroso-tin/system/config"
+	openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/rs/zerolog"
-	"golang.org/x/net/context"
 )
 
+type refundClient interface {
+	ListTicket(userData string, page int64) (ktmb.GenericRes[ktmb.TicketListRes], error)
+	GetRefundPolicy(userData, bookingData, ticketData string) (ktmb.GenericRes[ktmb.RefundPolicyRes], error)
+	RefundTicket(userData, password, bookingData, ticketData string) (ktmb.GenericRes[*interface{}], error)
+}
+
+type sessionProvider interface {
+	Login(ctx context.Context, email, password string) (string, error)
+}
+
+type refundReporter interface {
+	PostApiVVersionBookingIdKtmbRefund(ctx context.Context, version string, id openapi_types.UUID, body zinc.PostApiVVersionBookingIdKtmbRefundJSONBody, reqEditors ...zinc.RequestEditorFn) (*http.Response, error)
+}
+
 type Terminator struct {
-	ktmb         ktmb.Ktmb
-	session      *session.Session
+	ktmb         refundClient
+	session      sessionProvider
+	zinc         refundReporter
 	logger       *zerolog.Logger
 	enrichConfig config.EnricherConfig
 }
 
-func NewTerminator(ktmb ktmb.Ktmb, s *session.Session, logger *zerolog.Logger, enrichConfig config.EnricherConfig) Terminator {
+func NewTerminator(ktmb refundClient, s sessionProvider, zinc refundReporter, logger *zerolog.Logger, enrichConfig config.EnricherConfig) Terminator {
 	return Terminator{
 		ktmb:         ktmb,
 		logger:       logger,
 		session:      s,
+		zinc:         zinc,
 		enrichConfig: enrichConfig,
 	}
 }
@@ -57,10 +78,10 @@ func (t *Terminator) find(userData, bookingNo, ticketNo string, page int64) (str
 
 }
 
-func (t *Terminator) Terminate(termination BookingTermination) error {
+func (t *Terminator) Terminate(ctx context.Context, termination BookingTermination) error {
 
 	t.logger.Info().Msg("Logging in")
-	cred, err := t.session.Login(context.Background(), t.enrichConfig.Email, t.enrichConfig.Password)
+	cred, err := t.session.Login(ctx, t.enrichConfig.Email, t.enrichConfig.Password)
 	if err != nil {
 		t.logger.Error().Err(err).Msg("Failed to login")
 		return err
@@ -97,6 +118,65 @@ func (t *Terminator) Terminate(termination BookingTermination) error {
 		e := fmt.Errorf("failed to refund ticket: %+v", r.Messages)
 		t.logger.Error().Err(e).Strs("errors", r.Messages).Msg("Failed to refund ticket")
 		return e
+	}
+
+	amount, currency, ok := refundAmount(refundPolicy.Data, termination.TicketNo)
+	if !ok {
+		t.logger.Error().
+			Str("bookingId", termination.Id.String()).
+			Str("bookingNo", termination.BookingNo).
+			Str("ticketNo", termination.TicketNo).
+			Msg("KTMB refund succeeded but refund policy had no usable amount; leaving zinc refund missing for backfill")
+		return nil
+	}
+	if err := t.reportRefund(ctx, termination.Id, amount, currency); err != nil {
+		t.logger.Error().Err(err).
+			Str("bookingId", termination.Id.String()).
+			Str("bookingNo", termination.BookingNo).
+			Str("ticketNo", termination.TicketNo).
+			Msg("KTMB refund succeeded but reporting the refund to zinc failed; continuing")
+	}
+	return nil
+}
+
+func refundAmount(policy ktmb.RefundPolicyRes, ticketNo string) (float32, string, bool) {
+	for _, trip := range policy.Trips {
+		for _, ticket := range trip.Tickets {
+			if ticket.TicketNo == ticketNo && ticket.RefundAmount > 0 {
+				return ticket.RefundAmount, normalizeCurrency(ticket.CurrencyCode, policy.CurrencyCode), true
+			}
+		}
+	}
+	if policy.TotalRefundAmount > 0 {
+		return policy.TotalRefundAmount, normalizeCurrency(policy.CurrencyCode), true
+	}
+	return 0, "", false
+}
+
+func normalizeCurrency(currencies ...string) string {
+	for _, currency := range currencies {
+		if value := strings.ToUpper(strings.TrimSpace(currency)); value != "" {
+			return value
+		}
+	}
+	return "MYR"
+}
+
+func (t *Terminator) reportRefund(ctx context.Context, id openapi_types.UUID, amount float32, currency string) error {
+	if t.zinc == nil {
+		return fmt.Errorf("zinc refund reporter is not configured")
+	}
+	resp, err := t.zinc.PostApiVVersionBookingIdKtmbRefund(ctx, "1.0", id, zinc.PostApiVVersionBookingIdKtmbRefundJSONBody{
+		RefundAmount:   amount,
+		RefundCurrency: currency,
+	})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("status %d: %s", resp.StatusCode, string(body))
 	}
 	return nil
 }

--- a/lib/terminator/terminator_test.go
+++ b/lib/terminator/terminator_test.go
@@ -1,0 +1,133 @@
+package terminator
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/AtomiCloud/nitroso-tin/lib/ktmb"
+	"github.com/AtomiCloud/nitroso-tin/lib/zinc"
+	"github.com/AtomiCloud/nitroso-tin/system/config"
+	openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
+	"github.com/rs/zerolog"
+)
+
+type fakeRefundClient struct {
+	policy      ktmb.GenericRes[ktmb.RefundPolicyRes]
+	refund      ktmb.GenericRes[*interface{}]
+	refundCalls int
+}
+
+func (f *fakeRefundClient) ListTicket(string, int64) (ktmb.GenericRes[ktmb.TicketListRes], error) {
+	return ktmb.GenericRes[ktmb.TicketListRes]{Status: true, Data: ktmb.TicketListRes{
+		TotalPage: 1,
+		Bookings: []ktmb.TicketListBookingRes{{
+			BookingNo:   "B-1",
+			BookingData: "booking-data",
+			Trips: []ktmb.TicketListTripRes{{Tickets: []ktmb.TicketListTicketRes{{
+				TicketNo: "T-1", TicketData: "ticket-data",
+			}}}},
+		}},
+	}}, nil
+}
+
+func (f *fakeRefundClient) GetRefundPolicy(string, string, string) (ktmb.GenericRes[ktmb.RefundPolicyRes], error) {
+	return f.policy, nil
+}
+
+func (f *fakeRefundClient) RefundTicket(string, string, string, string) (ktmb.GenericRes[*interface{}], error) {
+	f.refundCalls++
+	return f.refund, nil
+}
+
+type fakeTermSession struct{}
+
+func (*fakeTermSession) Login(context.Context, string, string) (string, error) {
+	return "user-data", nil
+}
+
+type fakeReporter struct {
+	status int
+	err    error
+	id     openapi_types.UUID
+	body   zinc.PostApiVVersionBookingIdKtmbRefundJSONBody
+	calls  int
+}
+
+func (f *fakeReporter) PostApiVVersionBookingIdKtmbRefund(_ context.Context, _ string, id openapi_types.UUID, body zinc.PostApiVVersionBookingIdKtmbRefundJSONBody, _ ...zinc.RequestEditorFn) (*http.Response, error) {
+	f.calls++
+	f.id = id
+	f.body = body
+	if f.err != nil {
+		return nil, f.err
+	}
+	status := f.status
+	if status == 0 {
+		status = http.StatusNoContent
+	}
+	return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(""))}, nil
+}
+
+func terminationID(t *testing.T) openapi_types.UUID {
+	t.Helper()
+	var id openapi_types.UUID
+	if err := id.UnmarshalText([]byte("aaaaaaaa-0000-4000-8000-000000000001")); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+func successfulKTMB() *fakeRefundClient {
+	return &fakeRefundClient{
+		policy: ktmb.GenericRes[ktmb.RefundPolicyRes]{Status: true, Data: ktmb.RefundPolicyRes{
+			CurrencyCode:      "MYR",
+			TotalRefundAmount: 99,
+			Trips: []ktmb.RefundPolicyTripRes{{Tickets: []ktmb.RefundPolicyTripTicketRes{{
+				TicketNo: "T-1", RefundAmount: 8.5, CurrencyCode: "myr", TicketData: "policy-ticket-data",
+			}}}},
+		}},
+		refund: ktmb.GenericRes[*interface{}]{Status: true},
+	}
+}
+
+func TestTerminateReportsPerTicketRefundAfterKTMBSuccess(t *testing.T) {
+	ktmbClient := successfulKTMB()
+	reporter := &fakeReporter{}
+	logger := zerolog.Nop()
+	term := NewTerminator(ktmbClient, &fakeTermSession{}, reporter, &logger, config.EnricherConfig{Email: "e", Password: "p"})
+	id := terminationID(t)
+
+	if err := term.Terminate(context.Background(), BookingTermination{Id: id, BookingNo: "B-1", TicketNo: "T-1"}); err != nil {
+		t.Fatalf("Terminate returned error: %v", err)
+	}
+	if ktmbClient.refundCalls != 1 || reporter.calls != 1 || reporter.id != id {
+		t.Fatalf("refund calls=%d reporter calls=%d id=%s", ktmbClient.refundCalls, reporter.calls, reporter.id)
+	}
+	if reporter.body.RefundAmount != 8.5 || reporter.body.RefundCurrency != "MYR" {
+		t.Fatalf("reported refund = %+v, want per-ticket 8.5 MYR", reporter.body)
+	}
+}
+
+func TestTerminateDoesNotFailWhenZincRefundReportFails(t *testing.T) {
+	ktmbClient := successfulKTMB()
+	reporter := &fakeReporter{err: errors.New("zinc unavailable")}
+	logger := zerolog.Nop()
+	term := NewTerminator(ktmbClient, &fakeTermSession{}, reporter, &logger, config.EnricherConfig{Email: "e", Password: "p"})
+
+	if err := term.Terminate(context.Background(), BookingTermination{Id: terminationID(t), BookingNo: "B-1", TicketNo: "T-1"}); err != nil {
+		t.Fatalf("zinc report failure must not fail termination: %v", err)
+	}
+	if reporter.calls != 1 {
+		t.Fatalf("reporter calls=%d, want 1", reporter.calls)
+	}
+}
+
+func TestRefundAmountFallsBackToPolicyTotal(t *testing.T) {
+	amount, currency, ok := refundAmount(ktmb.RefundPolicyRes{TotalRefundAmount: 12, CurrencyCode: "sgd"}, "T-1")
+	if !ok || amount != 12 || currency != "SGD" {
+		t.Fatalf("refundAmount = (%v, %q, %v), want (12, SGD, true)", amount, currency, ok)
+	}
+}

--- a/lib/zinc/ktmb_cost.go
+++ b/lib/zinc/ktmb_cost.go
@@ -22,13 +22,23 @@ type BookingKtmbCostMissingRes struct {
 }
 
 type GetApiVVersionBookingKtmbCostMissingParams struct {
-	Limit *int32 `form:"Limit,omitempty" json:"Limit,omitempty"`
-	Skip  *int32 `form:"Skip,omitempty" json:"Skip,omitempty"`
+	Limit  *int32 `form:"Limit,omitempty" json:"Limit,omitempty"`
+	Skip   *int32 `form:"Skip,omitempty" json:"Skip,omitempty"`
+	Status *int   `form:"Status,omitempty" json:"Status,omitempty"`
+}
+
+type GetApiVVersionBookingKtmbRefundMissingParams struct {
+	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
 type PostApiVVersionBookingIdKtmbCostJSONBody struct {
 	Amount   float32 `json:"amount"`
 	Currency string  `json:"currency"`
+}
+
+type PostApiVVersionBookingIdKtmbRefundJSONBody struct {
+	RefundAmount   float32 `json:"refundAmount"`
+	RefundCurrency string  `json:"refundCurrency"`
 }
 
 func (c *Client) GetApiVVersionBookingKtmbCostMissing(ctx context.Context, version string, params *GetApiVVersionBookingKtmbCostMissingParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -45,6 +55,30 @@ func (c *Client) GetApiVVersionBookingKtmbCostMissing(ctx context.Context, versi
 
 func (c *Client) PostApiVVersionBookingIdKtmbCost(ctx context.Context, version string, id openapi_types.UUID, body PostApiVVersionBookingIdKtmbCostJSONBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPostApiVVersionBookingIdKtmbCostRequest(c.Server, version, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetApiVVersionBookingKtmbRefundMissing(ctx context.Context, version string, params *GetApiVVersionBookingKtmbRefundMissingParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetApiVVersionBookingKtmbRefundMissingRequest(c.Server, version, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostApiVVersionBookingIdKtmbRefund(ctx context.Context, version string, id openapi_types.UUID, body PostApiVVersionBookingIdKtmbRefundJSONBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostApiVVersionBookingIdKtmbRefundRequest(c.Server, version, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -72,6 +106,26 @@ func NewGetApiVVersionBookingKtmbCostMissingRequest(server, version string, para
 		if params.Skip != nil {
 			values.Set("Skip", fmt.Sprint(*params.Skip))
 		}
+		if params.Status != nil {
+			values.Set("Status", fmt.Sprint(*params.Status))
+		}
+		queryURL.RawQuery = values.Encode()
+	}
+	return http.NewRequest(http.MethodGet, queryURL.String(), nil)
+}
+
+func NewGetApiVVersionBookingKtmbRefundMissingRequest(server, version string, params *GetApiVVersionBookingKtmbRefundMissingParams) (*http.Request, error) {
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+	queryURL, err := serverURL.Parse(fmt.Sprintf("./api/v%s/Booking/ktmb-refund/missing", url.PathEscape(version)))
+	if err != nil {
+		return nil, err
+	}
+	if params != nil && params.Limit != nil {
+		values := queryURL.Query()
+		values.Set("limit", fmt.Sprint(*params.Limit))
 		queryURL.RawQuery = values.Encode()
 	}
 	return http.NewRequest(http.MethodGet, queryURL.String(), nil)
@@ -83,6 +137,27 @@ func NewPostApiVVersionBookingIdKtmbCostRequest(server, version string, id opena
 		return nil, err
 	}
 	requestURL, err := serverURL.Parse(fmt.Sprintf("./api/v%s/Booking/%s/ktmb-cost", url.PathEscape(version), url.PathEscape(id.String())))
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(http.MethodPost, requestURL.String(), bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+func NewPostApiVVersionBookingIdKtmbRefundRequest(server, version string, id openapi_types.UUID, body PostApiVVersionBookingIdKtmbRefundJSONBody) (*http.Request, error) {
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+	requestURL, err := serverURL.Parse(fmt.Sprintf("./api/v%s/Booking/%s/ktmb-refund", url.PathEscape(version), url.PathEscape(id.String())))
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -95,9 +95,20 @@ func main() {
 				Name:   "ktmb-cost-backfill",
 				Action: state.KtmbCostBackfill,
 				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:    "status",
+						Value:   "completed",
+						Usage:   "booking status whose purchase cost is backfilled: completed or terminated",
+						EnvVars: []string{"KTMB_COST_BACKFILL_STATUS"},
+					},
+					&cli.BoolFlag{
+						Name:    "refund",
+						Usage:   "probe and backfill exact refunds for terminated bookings",
+						EnvVars: []string{"KTMB_COST_BACKFILL_REFUND"},
+					},
 					&cli.BoolFlag{
 						Name:    "dry-run",
-						Usage:   "fetch and log KTMB costs without updating zinc",
+						Usage:   "fetch and log KTMB costs or refunds without updating zinc",
 						EnvVars: []string{"KTMB_COST_BACKFILL_DRY_RUN"},
 					},
 					&cli.IntFlag{


### PR DESCRIPTION
## Summary
- report the exact KTMB refund policy amount to zinc after a successful ticket refund without making zinc failures fatal
- add completed/terminated purchase-cost backfill selection and exact-only refund backfill with dry-run raw KTMB probing
- hand-declare the pinned zinc refund/missing endpoints and cover status, retry, dry-run, failure, and reporting behavior

## Integration note
The existing zinc termination queue payload currently carries only `bookingNo` and `ticketNo`. This PR extends that payload model with `id`; the parallel zinc change must emit the booking ID for live capture to address `POST /Booking/{id}/ktmb-refund`. Historical backfill does not depend on that queue-field addition.

## Probe result
A local `--refund --dry-run --max 1` attempt was blocked before KTMB by missing local Infisical/zinc credentials (`Missing access key for key exchange`). The command logs one raw GetTicket response at debug and probes GetRefundPolicy once credentials are available; it only posts exact `refundAmount`/`refundedAmount`/`totalRefundAmount` values and leaves unknown amounts missing.

## Validation
- `go test ./...`
- `go vet ./...`
- `nix develop .#ci --command ./scripts/ci/pre-commit.sh`