### PR TITLE
fix: keep KTMB refunds scoped to the requested ticket

### DIFF
--- a/lib/ktmbcost/client.go
+++ b/lib/ktmbcost/client.go
@@ -391,14 +391,21 @@ func ticketDataFrom(booking ktmb.GetTicketBookingRes, ticketNo string) (string, 
 }
 
 func refundFromPolicy(policy ktmb.RefundPolicyRes, ticketNo string) (float32, string, bool) {
+	var matched *ktmb.RefundPolicyTripTicketRes
+	ticketCount := 0
 	for _, trip := range policy.Trips {
-		for _, ticket := range trip.Tickets {
-			if ticket.TicketNo == ticketNo && ticket.RefundAmount > 0 {
-				return ticket.RefundAmount, normalizeCurrency(ticket.CurrencyCode, policy.CurrencyCode), true
+		for i := range trip.Tickets {
+			ticketCount++
+			ticket := &trip.Tickets[i]
+			if ticket.TicketNo == ticketNo {
+				matched = ticket
 			}
 		}
 	}
-	if policy.TotalRefundAmount > 0 {
+	if matched != nil && matched.RefundAmount > 0 {
+		return matched.RefundAmount, normalizeCurrency(matched.CurrencyCode, policy.CurrencyCode), true
+	}
+	if policy.TotalRefundAmount > 0 && (ticketCount == 0 || (ticketCount == 1 && matched != nil)) {
 		return policy.TotalRefundAmount, normalizeCurrency(policy.CurrencyCode), true
 	}
 	return 0, "", false
@@ -414,7 +421,35 @@ func refundFromRaw(raw json.RawMessage, ticketNo string) (float32, string, bool)
 	if amount, currency, ok := refundInTicketNode(root, ticketNo); ok {
 		return amount, currency, true
 	}
+	ticketCount, targetPresent := ticketNodeStats(root, ticketNo)
+	if ticketCount > 1 || (ticketCount > 0 && !targetPresent) {
+		return 0, "", false
+	}
 	return exactRefundInNode(root)
+}
+
+func ticketNodeStats(node any, ticketNo string) (int, bool) {
+	count := 0
+	found := false
+	switch value := node.(type) {
+	case map[string]any:
+		if _, ok := value["ticketNo"]; ok {
+			count++
+			found = stringField(value, "ticketNo") == ticketNo
+		}
+		for _, child := range value {
+			childCount, childFound := ticketNodeStats(child, ticketNo)
+			count += childCount
+			found = found || childFound
+		}
+	case []any:
+		for _, child := range value {
+			childCount, childFound := ticketNodeStats(child, ticketNo)
+			count += childCount
+			found = found || childFound
+		}
+	}
+	return count, found
 }
 
 func refundInTicketNode(node any, ticketNo string) (float32, string, bool) {

--- a/lib/ktmbcost/client_test.go
+++ b/lib/ktmbcost/client_test.go
@@ -553,6 +553,37 @@ func TestRunRefundLeavesMissingWhenKTMBHasNoExactAmount(t *testing.T) {
 	}
 }
 
+func TestRefundFromPolicyDoesNotAssignAMultiTicketTotalToOneTicket(t *testing.T) {
+	policy := ktmb.RefundPolicyRes{
+		TotalRefundAmount: 12,
+		CurrencyCode:      "MYR",
+		Trips: []ktmb.RefundPolicyTripRes{{Tickets: []ktmb.RefundPolicyTripTicketRes{
+			{TicketNo: "T-1"},
+			{TicketNo: "T-2", RefundAmount: 12},
+		}}},
+	}
+
+	if amount, currency, ok := refundFromPolicy(policy, "T-1"); ok {
+		t.Fatalf("refundFromPolicy = (%v, %q, true), want no exact amount for T-1", amount, currency)
+	}
+}
+
+func TestRefundFromRawDoesNotUseAnotherTicketsAmount(t *testing.T) {
+	raw := json.RawMessage(`{
+		"bookings": [{
+			"bookingNo": "B-1",
+			"trips": [{"tickets": [
+				{"ticketNo": "T-1"},
+				{"ticketNo": "T-2", "refundAmount": 7.5, "refundCurrency": "MYR"}
+			]}]
+		}]
+	}`)
+
+	if amount, currency, ok := refundFromRaw(raw, "T-1"); ok {
+		t.Fatalf("refundFromRaw = (%v, %q, true), want no exact amount for T-1", amount, currency)
+	}
+}
+
 func equalInts(left, right []int) bool {
 	if len(left) != len(right) {
 		return false

--- a/lib/terminator/terminator.go
+++ b/lib/terminator/terminator.go
@@ -61,9 +61,11 @@ func (t *Terminator) find(userData, bookingNo, ticketNo string, page int64) (str
 
 	for _, booking := range first.Data.Bookings {
 		if booking.BookingNo == bookingNo {
-			for _, ticket := range booking.Trips[0].Tickets {
-				if ticket.TicketNo == ticketNo {
-					return booking.BookingData, ticket.TicketData, nil
+			for _, trip := range booking.Trips {
+				for _, ticket := range trip.Tickets {
+					if ticket.TicketNo == ticketNo {
+						return booking.BookingData, ticket.TicketData, nil
+					}
 				}
 			}
 		}
@@ -108,7 +110,12 @@ func (t *Terminator) Terminate(ctx context.Context, termination BookingTerminati
 	}
 	t.logger.Info().Msg("Refunding Tickets")
 
-	r, err := t.ktmb.RefundTicket(cred, t.enrichConfig.Password, refundPolicy.Data.BookingData, refundPolicy.Data.Trips[0].Tickets[0].TicketData)
+	policyTicket, err := refundTicket(refundPolicy.Data, termination.TicketNo)
+	if err != nil {
+		t.logger.Error().Err(err).Msg("Refund policy did not contain the requested ticket")
+		return err
+	}
+	r, err := t.ktmb.RefundTicket(cred, t.enrichConfig.Password, refundPolicy.Data.BookingData, policyTicket.TicketData)
 	if err != nil {
 		t.logger.Error().Err(err).Msg("Failed to refund tickets")
 		return err
@@ -140,17 +147,53 @@ func (t *Terminator) Terminate(ctx context.Context, termination BookingTerminati
 }
 
 func refundAmount(policy ktmb.RefundPolicyRes, ticketNo string) (float32, string, bool) {
+	var matched *ktmb.RefundPolicyTripTicketRes
+	ticketCount := 0
 	for _, trip := range policy.Trips {
-		for _, ticket := range trip.Tickets {
-			if ticket.TicketNo == ticketNo && ticket.RefundAmount > 0 {
-				return ticket.RefundAmount, normalizeCurrency(ticket.CurrencyCode, policy.CurrencyCode), true
+		for i := range trip.Tickets {
+			ticketCount++
+			ticket := &trip.Tickets[i]
+			if ticket.TicketNo == ticketNo {
+				matched = ticket
 			}
 		}
 	}
-	if policy.TotalRefundAmount > 0 {
+	if matched != nil && matched.RefundAmount > 0 {
+		return matched.RefundAmount, normalizeCurrency(matched.CurrencyCode, policy.CurrencyCode), true
+	}
+	// TotalRefundAmount is an aggregate across the policy response. It is exact
+	// for this booking only when KTMB omitted ticket details, or when the target
+	// is the policy's sole ticket; using it for one ticket in a multi-ticket
+	// policy would overstate that booking's refund.
+	if policy.TotalRefundAmount > 0 && (ticketCount == 0 || (ticketCount == 1 && matched != nil)) {
 		return policy.TotalRefundAmount, normalizeCurrency(policy.CurrencyCode), true
 	}
 	return 0, "", false
+}
+
+func refundTicket(policy ktmb.RefundPolicyRes, ticketNo string) (ktmb.RefundPolicyTripTicketRes, error) {
+	var sole *ktmb.RefundPolicyTripTicketRes
+	ticketCount := 0
+	for _, trip := range policy.Trips {
+		for i := range trip.Tickets {
+			ticketCount++
+			ticket := &trip.Tickets[i]
+			if ticket.TicketNo == ticketNo {
+				if ticket.TicketData == "" {
+					return ktmb.RefundPolicyTripTicketRes{}, fmt.Errorf("refund policy ticket %q has no ticket data", ticketNo)
+				}
+				return *ticket, nil
+			}
+			sole = ticket
+		}
+	}
+	// Some KTMB responses omit TicketNo after the caller already selected one.
+	// A sole anonymous ticket is still unambiguous; an explicitly different or
+	// multi-ticket response is not.
+	if ticketCount == 1 && sole != nil && sole.TicketNo == "" && sole.TicketData != "" {
+		return *sole, nil
+	}
+	return ktmb.RefundPolicyTripTicketRes{}, fmt.Errorf("refund policy does not contain ticket %q", ticketNo)
 }
 
 func normalizeCurrency(currencies ...string) string {

--- a/lib/terminator/terminator_test.go
+++ b/lib/terminator/terminator_test.go
@@ -19,9 +19,14 @@ type fakeRefundClient struct {
 	policy      ktmb.GenericRes[ktmb.RefundPolicyRes]
 	refund      ktmb.GenericRes[*interface{}]
 	refundCalls int
+	list        *ktmb.GenericRes[ktmb.TicketListRes]
+	refunded    string
 }
 
 func (f *fakeRefundClient) ListTicket(string, int64) (ktmb.GenericRes[ktmb.TicketListRes], error) {
+	if f.list != nil {
+		return *f.list, nil
+	}
 	return ktmb.GenericRes[ktmb.TicketListRes]{Status: true, Data: ktmb.TicketListRes{
 		TotalPage: 1,
 		Bookings: []ktmb.TicketListBookingRes{{
@@ -38,8 +43,9 @@ func (f *fakeRefundClient) GetRefundPolicy(string, string, string) (ktmb.Generic
 	return f.policy, nil
 }
 
-func (f *fakeRefundClient) RefundTicket(string, string, string, string) (ktmb.GenericRes[*interface{}], error) {
+func (f *fakeRefundClient) RefundTicket(_, _, _, ticketData string) (ktmb.GenericRes[*interface{}], error) {
 	f.refundCalls++
+	f.refunded = ticketData
 	return f.refund, nil
 }
 
@@ -125,9 +131,63 @@ func TestTerminateDoesNotFailWhenZincRefundReportFails(t *testing.T) {
 	}
 }
 
+func TestTerminateRefundsTheRequestedTicketFromAMultiTicketPolicy(t *testing.T) {
+	listing := ktmb.GenericRes[ktmb.TicketListRes]{Status: true, Data: ktmb.TicketListRes{
+		TotalPage: 1,
+		Bookings: []ktmb.TicketListBookingRes{{
+			BookingNo:   "B-1",
+			BookingData: "booking-data",
+			Trips: []ktmb.TicketListTripRes{{Tickets: []ktmb.TicketListTicketRes{
+				{TicketNo: "T-1", TicketData: "list-ticket-data-1"},
+				{TicketNo: "T-2", TicketData: "list-ticket-data-2"},
+			}}},
+		}},
+	}}
+	ktmbClient := &fakeRefundClient{
+		list: &listing,
+		policy: ktmb.GenericRes[ktmb.RefundPolicyRes]{Status: true, Data: ktmb.RefundPolicyRes{
+			BookingData:  "policy-booking-data",
+			CurrencyCode: "MYR",
+			Trips: []ktmb.RefundPolicyTripRes{{Tickets: []ktmb.RefundPolicyTripTicketRes{
+				{TicketNo: "T-1", RefundAmount: 4, TicketData: "policy-ticket-data-1"},
+				{TicketNo: "T-2", RefundAmount: 8, TicketData: "policy-ticket-data-2"},
+			}}},
+		}},
+		refund: ktmb.GenericRes[*interface{}]{Status: true},
+	}
+	reporter := &fakeReporter{}
+	logger := zerolog.Nop()
+	term := NewTerminator(ktmbClient, &fakeTermSession{}, reporter, &logger, config.EnricherConfig{Email: "e", Password: "p"})
+
+	if err := term.Terminate(context.Background(), BookingTermination{Id: terminationID(t), BookingNo: "B-1", TicketNo: "T-2"}); err != nil {
+		t.Fatalf("Terminate returned error: %v", err)
+	}
+	if ktmbClient.refunded != "policy-ticket-data-2" {
+		t.Fatalf("RefundTicket ticketData = %q, want requested ticket's policy-ticket-data-2", ktmbClient.refunded)
+	}
+	if reporter.body.RefundAmount != 8 {
+		t.Fatalf("reported refund = %+v, want requested ticket's amount 8", reporter.body)
+	}
+}
+
 func TestRefundAmountFallsBackToPolicyTotal(t *testing.T) {
 	amount, currency, ok := refundAmount(ktmb.RefundPolicyRes{TotalRefundAmount: 12, CurrencyCode: "sgd"}, "T-1")
 	if !ok || amount != 12 || currency != "SGD" {
 		t.Fatalf("refundAmount = (%v, %q, %v), want (12, SGD, true)", amount, currency, ok)
+	}
+}
+
+func TestRefundAmountDoesNotAssignAMultiTicketTotalToOneTicket(t *testing.T) {
+	policy := ktmb.RefundPolicyRes{
+		TotalRefundAmount: 12,
+		CurrencyCode:      "MYR",
+		Trips: []ktmb.RefundPolicyTripRes{{Tickets: []ktmb.RefundPolicyTripTicketRes{
+			{TicketNo: "T-1"},
+			{TicketNo: "T-2", RefundAmount: 12},
+		}}},
+	}
+
+	if amount, currency, ok := refundAmount(policy, "T-1"); ok {
+		t.Fatalf("refundAmount = (%v, %q, true), want no exact amount for T-1", amount, currency)
 	}
 }


### PR DESCRIPTION
## Summary

- select the requested ticket data from multi-ticket refund policies before calling KTMB
- refuse to assign aggregate `TotalRefundAmount` to one ticket when the policy contains multiple tickets
- keep raw refund backfill from falling through to another ticket amount
- scan every trip when locating the requested ticket

## Confirmed failures

- for target `T-2` in a policy ordered `[T-1, T-2]`, live termination refunded `T-1` while reporting `T-2` amount to zinc
- for target `T-1` with no per-ticket amount and another ticket carrying MYR 12, both live capture and backfill recorded the aggregate/other-ticket MYR 12 as `T-1` exact refund

## Validation

- failing reproductions added before the fix for live selection, policy fallback, and raw fallback
- `go test ./...`
- `go vet ./...`
- `nix develop .#ci --command ./scripts/ci/pre-commit.sh`