### PR TITLE
fix(prober): classify KTMB 'Not enough seat' as sold-out

### DIFF
--- a/config/app/settings.yaml
+++ b/config/app/settings.yaml
@@ -181,6 +181,9 @@ prober:
     - 'sold out'
     - 'no seat'
     - 'not available'
+    # verbatim from the pikachu Phase-0 dry-run (EPOCH-PROBER.md §9): KTMB's
+    # actual full-slot phrasing is "Not enough seat for onward trip."
+    - 'not enough seat'
   staleDataPatterns:
     - 'search data'
     - 'trip data'

--- a/infra/consumer_chart/app/settings.yaml
+++ b/infra/consumer_chart/app/settings.yaml
@@ -181,6 +181,9 @@ prober:
     - 'sold out'
     - 'no seat'
     - 'not available'
+    # verbatim from the pikachu Phase-0 dry-run (EPOCH-PROBER.md §9): KTMB's
+    # actual full-slot phrasing is "Not enough seat for onward trip."
+    - 'not enough seat'
   staleDataPatterns:
     - 'search data'
     - 'trip data'


### PR DESCRIPTION
Phase-0 dry-run finding on pikachu: KTMB's actual full-slot Reserve response is 'Not enough seat for onward trip.' — none of the soldOutPatterns matched it, so probes were tallied as errors and each Job bailed at errorLimit=5 instead of retrying until its deadline. Adds the verbatim phrase to soldOutPatterns.

https://claude.ai/code/session_018kJbfRkYZXikAELSDPj7pX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved availability detection for KTMB trips that report insufficient seats for onward travel.
  * These trips are now correctly identified as sold out.
  * Expanded the sold-out matching to include the “Not enough seat” phrasing used in KTMB full-slot responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->