### PR TITLE
feat: configurable prober Job resources

### DIFF
--- a/cmds/spawner.go
+++ b/cmds/spawner.go
@@ -51,7 +51,8 @@ func (state *State) Spawner(c *cli.Context) error {
 		ktmbConfig.LoginKey, state.Ps+":prober:session-dead", state.Logger)
 	counts := count.New(state.Config.Buffer, &mainRedis, state.Logger, state.Ps, state.Location)
 	jobs := prober.NewJobCreator(kube, namespace, container, pod.Spec.Volumes,
-		state.Config.App, state.Config.Prober.JobMinutes, state.Logger)
+		state.Config.App, state.Config.Prober.JobMinutes, state.Config.Prober.JobCpu,
+		state.Config.Prober.JobMemory, state.Logger)
 	spawner := prober.NewSpawner(counts, store, jobs, &mainRedis, state.Config.Prober, state.Ps, state.Logger)
 	state.Logger.Info().Msg("Starting epoch prober spawner")
 	return spawner.Start(ctx)

--- a/config/app/settings.yaml
+++ b/config/app/settings.yaml
@@ -164,6 +164,8 @@ poller:
 prober:
   epochMinutes: 1
   jobMinutes: 2
+  jobCpu: '250m'
+  jobMemory: '128Mi'
   slotsPerJob: 500
   fanout: 1
   paceMs: 0

--- a/infra/consumer_chart/app/settings.yaml
+++ b/infra/consumer_chart/app/settings.yaml
@@ -164,6 +164,8 @@ poller:
 prober:
   epochMinutes: 1
   jobMinutes: 2
+  jobCpu: '250m'
+  jobMemory: '128Mi'
   slotsPerJob: 500
   fanout: 1
   paceMs: 0

--- a/lib/prober/job.go
+++ b/lib/prober/job.go
@@ -23,14 +23,17 @@ type JobCreator struct {
 	volumes    []corev1.Volume
 	app        config.AppConfig
 	jobMinutes int
+	jobCpu     string
+	jobMemory  string
 	logger     *zerolog.Logger
 }
 
 func NewJobCreator(kube kubernetes.Interface, namespace string, container corev1.Container,
-	volumes []corev1.Volume, app config.AppConfig, jobMinutes int,
+	volumes []corev1.Volume, app config.AppConfig, jobMinutes int, jobCpu, jobMemory string,
 	logger *zerolog.Logger) *JobCreator {
 	return &JobCreator{kube: kube, namespace: namespace, container: container,
-		volumes: volumes, app: app, jobMinutes: jobMinutes, logger: logger}
+		volumes: volumes, app: app, jobMinutes: jobMinutes, jobCpu: jobCpu,
+		jobMemory: jobMemory, logger: logger}
 }
 
 func JobName(epoch int64, shard, fanout int) string {
@@ -52,9 +55,21 @@ func (c *JobCreator) Create(ctx context.Context, epoch int64, shard, fanout int,
 	container.StartupProbe = nil
 	container.Lifecycle = nil
 	container.Ports = nil
+	jobCpu := c.jobCpu
+	if jobCpu == "" {
+		jobCpu = "250m"
+	}
+	jobMemory := c.jobMemory
+	if jobMemory == "" {
+		jobMemory = "128Mi"
+	}
+	requests := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse(jobCpu),
+		corev1.ResourceMemory: resource.MustParse(jobMemory),
+	}
 	container.Resources = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m"), corev1.ResourceMemory: resource.MustParse("128Mi")},
-		Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m"), corev1.ResourceMemory: resource.MustParse("128Mi")},
+		Requests: requests,
+		Limits:   requests.DeepCopy(),
 	}
 	container.Env = append(container.Env, corev1.EnvVar{Name: "ATOMI_APP__MODULE", Value: "prober"})
 

--- a/lib/prober/job_test.go
+++ b/lib/prober/job_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/AtomiCloud/nitroso-tin/system/config"
 	"github.com/rs/zerolog"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -21,7 +22,8 @@ func TestJobCreatorBuildsDeterministicCacheOnlyJob(t *testing.T) {
 		VolumeMounts: []corev1.VolumeMount{{Name: "config", MountPath: "/app/config"}},
 	}
 	creator := NewJobCreator(kube, "nitroso", container,
-		[]corev1.Volume{{Name: "config"}}, config.AppConfig{Landscape: "pichu", Platform: "nitroso", Service: "tin"}, 2, &logger)
+		[]corev1.Volume{{Name: "config"}}, config.AppConfig{Landscape: "pichu", Platform: "nitroso", Service: "tin"},
+		2, "1", "1Gi", &logger)
 	targets := []Target{{Direction: "JToW", Date: "01-01-2027", Time: "08:30:00", Needed: 2}}
 
 	if err := creator.Create(context.Background(), 123, 4, 1, targets); err != nil {
@@ -56,10 +58,46 @@ func TestJobCreatorBuildsDeterministicCacheOnlyJob(t *testing.T) {
 	if len(got.EnvFrom) != 1 || got.EnvFrom[0].SecretRef.Name != "tin" {
 		t.Fatalf("spawned Job did not inherit runtime secret: %#v", got.EnvFrom)
 	}
+	assertContainerResources(t, got, "1", "1Gi")
+}
+
+func TestJobCreatorUsesDefaultResourcesWhenUnset(t *testing.T) {
+	kube := fake.NewSimpleClientset()
+	logger := zerolog.Nop()
+	creator := NewJobCreator(kube, "nitroso", corev1.Container{}, nil, config.AppConfig{},
+		1, "", "", &logger)
+
+	if err := creator.Create(context.Background(), 456, 0, 0, nil); err != nil {
+		t.Fatal(err)
+	}
+	job, err := kube.BatchV1().Jobs("nitroso").Get(context.Background(), "tin-prober-456-0-0", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertContainerResources(t, job.Spec.Template.Spec.Containers[0], "250m", "128Mi")
 }
 
 func TestContainerFromPodRejectsEmptyPod(t *testing.T) {
 	if _, err := ContainerFromPod(&corev1.Pod{}); err == nil {
 		t.Fatal("expected empty pod to fail")
+	}
+}
+
+func assertContainerResources(t *testing.T, container corev1.Container, cpu, memory string) {
+	t.Helper()
+	wantCPU := resource.MustParse(cpu)
+	wantMemory := resource.MustParse(memory)
+	for name, resources := range map[string]corev1.ResourceList{
+		"requests": container.Resources.Requests,
+		"limits":   container.Resources.Limits,
+	} {
+		gotCPU, ok := resources[corev1.ResourceCPU]
+		if !ok || gotCPU.Cmp(wantCPU) != 0 {
+			t.Errorf("%s CPU = %v, want %s", name, gotCPU.String(), cpu)
+		}
+		gotMemory, ok := resources[corev1.ResourceMemory]
+		if !ok || gotMemory.Cmp(wantMemory) != 0 {
+			t.Errorf("%s memory = %v, want %s", name, gotMemory.String(), memory)
+		}
 	}
 }

--- a/system/config/loader_test.go
+++ b/system/config/loader_test.go
@@ -12,11 +12,12 @@ func TestLoaderReadsProberDefaults(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := ProberConfig{
-		EpochMinutes: 1, JobMinutes: 2, SlotsPerJob: 500, Fanout: 1,
+		EpochMinutes: 1, JobMinutes: 2, JobCpu: "250m", JobMemory: "128Mi",
+		SlotsPerJob: 500, Fanout: 1,
 		PaceMs: 0, DryRun: true, ErrorLimit: 5, ErrorBackoffMs: 100,
 		ReleaseDrainLimit: 10, ReleaseDrainBudgetMs: 5000,
 		ReleaseTerminalPatterns: []string{"not found", "booking expired", "invalid booking"},
-		SoldOutPatterns:         []string{"sold out", "no seat", "not available"},
+		SoldOutPatterns:         []string{"sold out", "no seat", "not available", "not enough seat"},
 		StaleDataPatterns:       []string{"search data", "trip data", "expired"},
 		SessionPatterns:         []string{"session", "login", "unauthorized"},
 		RateLimitPatterns:       []string{"too many requests", "rate limit"},

--- a/system/config/model.go
+++ b/system/config/model.go
@@ -216,6 +216,8 @@ type PollerConfig struct {
 type ProberConfig struct {
 	EpochMinutes            int
 	JobMinutes              int
+	JobCpu                  string
+	JobMemory               string
 	SlotsPerJob             int
 	Fanout                  int
 	PaceMs                  int


### PR DESCRIPTION
## Summary
- add `prober.jobCpu` and `prober.jobMemory` configuration with backward-compatible `250m` / `128Mi` defaults
- apply configured CPU and memory to both Job requests and limits, preserving Guaranteed QoS
- wire the spawner config and sync the consumer-chart settings mirror
- cover configured values, empty-value fallback, and loader defaults in tests

## Why
Pikachu load testing needs a larger prober pod to measure the true throughput ceiling without MAIN-Redis startup timeouts caused by the hardcoded resource floor. This change enables per-landscape overrides while preserving current defaults everywhere.

## Validation
- `go build ./...`
- `go test ./...`
- `CGO_ENABLED=1 go test -ldflags=-linkmode=external ./lib/prober`
- `go vet ./...`
- `pre-commit run a-config-sync --all-files`
- `helm lint ./infra/root_chart --values ./infra/root_chart/values.yaml --values ./infra/root_chart/values.pikachu.yaml`
- `helm template tin ./infra/root_chart --values ./infra/root_chart/values.yaml --values ./infra/root_chart/values.pikachu.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable CPU and memory resources for probe jobs.
  * Probe jobs now use configured resource values when provided, with sensible defaults otherwise.
  * Added default resource settings to application deployments.

* **Bug Fixes**
  * Improved sold-out detection by recognizing “not enough seat” messages.

* **Tests**
  * Added coverage for custom and default probe-job resource settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->