### PR TITLE
fix: dial external Redis as FQDN to stop ndots search-domain amplification

### DIFF
--- a/lib/otelredis/redis.go
+++ b/lib/otelredis/redis.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
+	"strings"
+
 	"github.com/AtomiCloud/nitroso-tin/system/config"
 	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog"
@@ -28,6 +31,26 @@ type OtelRedisMessage struct {
 	Context propagation.MapCarrier `json:"context"`
 }
 
+func fqdnHost(host string) string {
+	if net.ParseIP(host) != nil || !strings.Contains(host, ".") || strings.HasSuffix(host, ".") {
+		return host
+	}
+
+	return host + "."
+}
+
+func normalizeRedisOptions(opt *redis.Options) {
+	host, port, err := net.SplitHostPort(opt.Addr)
+	if err != nil {
+		return
+	}
+
+	opt.Addr = net.JoinHostPort(fqdnHost(host), port)
+	if opt.TLSConfig != nil {
+		opt.TLSConfig.ServerName = strings.TrimSuffix(host, ".")
+	}
+}
+
 func New(cfg config.CacheConfig) OtelRedis {
 
 	ssl := ""
@@ -37,6 +60,7 @@ func New(cfg config.CacheConfig) OtelRedis {
 
 	ep := fmt.Sprintf("redis%s://default:%s@%s", ssl, cfg.Password, cfg.Endpoints[0])
 	opt, _ := redis.ParseURL(ep)
+	normalizeRedisOptions(opt)
 	rdb := redis.NewClient(opt)
 	return OtelRedis{rdb}
 }

--- a/lib/otelredis/redis_test.go
+++ b/lib/otelredis/redis_test.go
@@ -2,11 +2,92 @@ package otelredis
 
 import (
 	"context"
+	"net"
+	"strings"
 	"testing"
 
+	"github.com/AtomiCloud/nitroso-tin/system/config"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel"
 )
+
+func TestFQDNHost(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{
+			name: "external hostname",
+			host: "relaxed-foxhound-32927.upstash.io",
+			want: "relaxed-foxhound-32927.upstash.io.",
+		},
+		{
+			name: "cluster short name",
+			host: "zinc-maincache",
+			want: "zinc-maincache",
+		},
+		{
+			name: "cluster FQDN",
+			host: "foo.bar.svc.cluster.local",
+			want: "foo.bar.svc.cluster.local.",
+		},
+		{
+			name: "already absolute",
+			host: "x.y.",
+			want: "x.y.",
+		},
+		{
+			name: "IPv4 address",
+			host: "10.0.0.1",
+			want: "10.0.0.1",
+		},
+		{
+			name: "IPv6 address",
+			host: "2001:db8::1",
+			want: "2001:db8::1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := fqdnHost(tt.host); got != tt.want {
+				t.Fatalf("fqdnHost(%q) = %q, want %q", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewUsesAbsoluteDialHostAndBareTLSServerName(t *testing.T) {
+	const host = "relaxed-foxhound-32927.upstash.io"
+
+	rdb := New(config.CacheConfig{
+		Password: "fake-password",
+		Ssl:      true,
+		Endpoints: map[int]string{
+			0: net.JoinHostPort(host, "6379"),
+		},
+	})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	opt := rdb.Options()
+	dialHost, _, err := net.SplitHostPort(opt.Addr)
+	if err != nil {
+		t.Fatalf("split Redis address %q: %v", opt.Addr, err)
+	}
+	if dialHost != host+"." {
+		t.Fatalf("Redis dial host = %q, want %q", dialHost, host+".")
+	}
+	if opt.TLSConfig == nil {
+		t.Fatal("expected TLS config for SSL Redis client")
+	}
+	if opt.TLSConfig.ServerName != host {
+		t.Fatalf("TLS ServerName = %q, want bare host %q", opt.TLSConfig.ServerName, host)
+	}
+	if strings.HasSuffix(opt.TLSConfig.ServerName, ".") {
+		t.Fatalf("TLS ServerName must not end in a dot: %q", opt.TLSConfig.ServerName)
+	}
+}
 
 // QueuePush must surface a failed LPUSH as an error rather than reporting
 // success. go-redis stores execution errors on the returned *IntCmd, so a bare


### PR DESCRIPTION
## Summary

- make dotted Redis hostnames absolute before dialing so Kubernetes resolvers skip search-domain expansion
- leave cluster short names and IP addresses unchanged
- keep TLS certificate verification on the bare, dot-free hostname
- add unit coverage for external, cluster, already-absolute, IPv4, IPv6, and TLS cases

## Why

With ndots:5, the external Upstash hostname is otherwise tried against each cluster search domain before the real name. The trailing dot reduces each resolution from four DNS queries to one and avoids startup bursts overwhelming CoreDNS.

## Validation

- go build ./...
- go test ./...
- go vet ./...

## Deployment note

Live TLS connectivity to Upstash must be smoke-verified on the pikachu deployment because CI cannot reach Upstash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis connection handling for hostname-based endpoints.
  * Ensured TLS connections use the correct server name while preserving reliable hostname resolution.
  * Added coverage for external domains, cluster hostnames, IP addresses, and secure Redis connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->