### PR TITLE
feat: flag-gated pprof profiling for the prober

### DIFF
--- a/cmds/prober.go
+++ b/cmds/prober.go
@@ -2,6 +2,9 @@ package cmds
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/AtomiCloud/nitroso-tin/lib/encryptor"
@@ -14,7 +17,19 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func (state *State) Prober(c *cli.Context) error {
+func (state *State) Prober(c *cli.Context) (runErr error) {
+	profiler, err := prober.StartProfiler(c.Bool("pprof"), os.Stdout)
+	if err != nil {
+		return fmt.Errorf("start prober profiler: %w", err)
+	}
+	if profiler != nil {
+		defer func() {
+			if err := profiler.Stop(); err != nil {
+				runErr = errors.Join(runErr, fmt.Errorf("stop prober profiler: %w", err))
+			}
+		}()
+	}
+
 	targets, err := prober.ParseTargets(c.String("data"))
 	if err != nil {
 		return err

--- a/docs/EPOCH-PROBER.md
+++ b/docs/EPOCH-PROBER.md
@@ -355,6 +355,44 @@ loop until deadline or holds == needed:
 - Prometheus stays out of scope for v1; logs + redis tally are sufficient and
   match the fleet's existing observability posture.
 
+### 8.1 On-demand runtime profiles
+
+Runtime profiling is default-off and has no sampling or buffering cost unless the
+prober receives `--pprof` or `ATOMI_PROBER__PPROF=true`. An enabled Job records CPU
+for the full prober action, then captures heap, goroutine, block, and mutex profiles
+at exit. Each profile is gzip-wrapped, base64-encoded, and emitted as one raw log
+line with a stable `PPROF-<TYPE>-B64:` prefix.
+
+The spawner copies its container environment into each short-lived Job. To profile
+one pikachu Job, enable the environment variable on the spawner, wait for the next
+Job after the rollout, then immediately turn it back off:
+
+```bash
+kubectl --context pikachu-ruby -n nitroso set env deployment/tin-spawner ATOMI_PROBER__PPROF=true
+kubectl --context pikachu-ruby -n nitroso rollout status deployment/tin-spawner --timeout=2m
+PREVIOUS_JOB=$(kubectl --context pikachu-ruby -n nitroso get jobs -l atomi.cloud/module=prober --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1:].metadata.name}')
+while :; do
+  JOB=$(kubectl --context pikachu-ruby -n nitroso get jobs -l atomi.cloud/module=prober --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1:].metadata.name}')
+  [ -n "${JOB}" ] && [ "${JOB}" != "${PREVIOUS_JOB}" ] && break
+  sleep 5
+done
+kubectl --context pikachu-ruby -n nitroso set env deployment/tin-spawner ATOMI_PROBER__PPROF-
+kubectl --context pikachu-ruby -n nitroso rollout status deployment/tin-spawner --timeout=2m
+```
+
+Retrieve and reconstruct all five profiles before the completed Job's five-minute
+TTL expires:
+
+```bash
+until kubectl --context pikachu-ruby -n nitroso logs "job/${JOB}" | grep -q '^PPROF-MUTEX-B64:'; do sleep 5; done
+kubectl --context pikachu-ruby -n nitroso logs "job/${JOB}" > "${JOB}.log"
+for PROFILE in CPU HEAP GOROUTINE BLOCK MUTEX; do
+  name=$(printf '%s' "${PROFILE}" | tr '[:upper:]' '[:lower:]')
+  sed -n "s/^PPROF-${PROFILE}-B64://p" "${JOB}.log" | tail -n 1 | base64 -d | gzip -dc > "${name}.pprof"
+done
+go tool pprof -top cpu.pprof
+```
+
 ## 9. Migration plan (each phase independently shippable / revertible)
 
 - **Phase 0 — validate (§10)** on pichu by enabling only `spawner.enabled` while

--- a/docs/EPOCH-PROBER.md
+++ b/docs/EPOCH-PROBER.md
@@ -364,16 +364,24 @@ at exit. Each profile is gzip-wrapped, base64-encoded, and emitted as one raw lo
 line with a stable `PPROF-<TYPE>-B64:` prefix.
 
 The spawner copies its container environment into each short-lived Job. To profile
-one pikachu Job, enable the environment variable on the spawner, wait for the next
-Job after the rollout, then immediately turn it back off:
+the next pikachu batch, record the start time, enable the environment variable on
+the spawner, select the first new Job whose template carries the flag, then
+immediately turn it back off:
 
 ```bash
+STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 kubectl --context pikachu-ruby -n nitroso set env deployment/tin-spawner ATOMI_PROBER__PPROF=true
 kubectl --context pikachu-ruby -n nitroso rollout status deployment/tin-spawner --timeout=2m
-PREVIOUS_JOB=$(kubectl --context pikachu-ruby -n nitroso get jobs -l atomi.cloud/module=prober --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1:].metadata.name}')
 while :; do
-  JOB=$(kubectl --context pikachu-ruby -n nitroso get jobs -l atomi.cloud/module=prober --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1:].metadata.name}')
-  [ -n "${JOB}" ] && [ "${JOB}" != "${PREVIOUS_JOB}" ] && break
+  JOB=$(kubectl --context pikachu-ruby -n nitroso get jobs -l atomi.cloud/module=prober -o json | jq -r --arg started "${STARTED_AT}" '
+    [.items[]
+      | select(.metadata.creationTimestamp >= $started)
+      | select([.spec.template.spec.containers[].env[]?
+          | select(.name == "ATOMI_PROBER__PPROF" and .value == "true")] | length > 0)]
+    | sort_by(.metadata.creationTimestamp)
+    | .[0].metadata.name // empty
+  ')
+  [ -n "${JOB}" ] && break
   sleep 5
 done
 kubectl --context pikachu-ruby -n nitroso set env deployment/tin-spawner ATOMI_PROBER__PPROF-

--- a/lib/prober/profiler.go
+++ b/lib/prober/profiler.go
@@ -1,0 +1,123 @@
+package prober
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"runtime"
+	"runtime/pprof"
+	"sync"
+)
+
+const (
+	profileCPUPrefix       = "PPROF-CPU-B64:"
+	profileHeapPrefix      = "PPROF-HEAP-B64:"
+	profileGoroutinePrefix = "PPROF-GOROUTINE-B64:"
+	profileBlockPrefix     = "PPROF-BLOCK-B64:"
+	profileMutexPrefix     = "PPROF-MUTEX-B64:"
+)
+
+type capturedProfile struct {
+	name   string
+	prefix string
+	data   []byte
+}
+
+// Profiler captures a CPU profile for its full lifetime and emits terminal
+// runtime profiles when stopped. A nil *Profiler is the disabled session.
+type Profiler struct {
+	output                       io.Writer
+	cpu                          bytes.Buffer
+	previousMutexProfileFraction int
+	stopOnce                     sync.Once
+	stopErr                      error
+}
+
+// StartProfiler returns nil without allocating buffers or enabling runtime
+// sampling when enabled is false.
+func StartProfiler(enabled bool, output io.Writer) (*Profiler, error) {
+	if !enabled {
+		return nil, nil
+	}
+	if output == nil {
+		return nil, errors.New("profile output is required")
+	}
+
+	profiler := &Profiler{output: output}
+	runtime.SetBlockProfileRate(1)
+	profiler.previousMutexProfileFraction = runtime.SetMutexProfileFraction(1)
+	if err := pprof.StartCPUProfile(&profiler.cpu); err != nil {
+		runtime.SetBlockProfileRate(0)
+		runtime.SetMutexProfileFraction(profiler.previousMutexProfileFraction)
+		return nil, fmt.Errorf("start CPU profile: %w", err)
+	}
+	return profiler, nil
+}
+
+// Stop ends CPU profiling, captures the terminal profiles, disables sampling,
+// and writes one gzip+base64 log line per profile. It is safe to call twice.
+func (p *Profiler) Stop() error {
+	if p == nil {
+		return nil
+	}
+	p.stopOnce.Do(func() {
+		p.stopErr = p.stop()
+	})
+	return p.stopErr
+}
+
+func (p *Profiler) stop() error {
+	pprof.StopCPUProfile()
+
+	var stopErr error
+	profiles := []capturedProfile{{name: "cpu", prefix: profileCPUPrefix, data: p.cpu.Bytes()}}
+	runtime.GC()
+	for _, spec := range []struct {
+		name   string
+		prefix string
+	}{
+		{name: "heap", prefix: profileHeapPrefix},
+		{name: "goroutine", prefix: profileGoroutinePrefix},
+		{name: "block", prefix: profileBlockPrefix},
+		{name: "mutex", prefix: profileMutexPrefix},
+	} {
+		profile := pprof.Lookup(spec.name)
+		if profile == nil {
+			stopErr = errors.Join(stopErr, fmt.Errorf("runtime profile %q is unavailable", spec.name))
+			continue
+		}
+		var data bytes.Buffer
+		if err := profile.WriteTo(&data, 0); err != nil {
+			stopErr = errors.Join(stopErr, fmt.Errorf("capture %s profile: %w", spec.name, err))
+			continue
+		}
+		profiles = append(profiles, capturedProfile{name: spec.name, prefix: spec.prefix, data: data.Bytes()})
+	}
+
+	runtime.SetBlockProfileRate(0)
+	runtime.SetMutexProfileFraction(p.previousMutexProfileFraction)
+
+	for _, profile := range profiles {
+		if err := writeProfileLine(p.output, profile.prefix, profile.data); err != nil {
+			stopErr = errors.Join(stopErr, fmt.Errorf("emit %s profile: %w", profile.name, err))
+		}
+	}
+	return stopErr
+}
+
+func writeProfileLine(output io.Writer, prefix string, profile []byte) error {
+	var compressed bytes.Buffer
+	zipper := gzip.NewWriter(&compressed)
+	if _, err := zipper.Write(profile); err != nil {
+		return err
+	}
+	if err := zipper.Close(); err != nil {
+		return err
+	}
+	encoded := base64.StdEncoding.EncodeToString(compressed.Bytes())
+	_, err := fmt.Fprintf(output, "%s%s\n", prefix, encoded)
+	return err
+}

--- a/lib/prober/profiler_test.go
+++ b/lib/prober/profiler_test.go
@@ -1,0 +1,83 @@
+package prober
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProfilerDisabledIsInert(t *testing.T) {
+	profiler, err := StartProfiler(false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if profiler != nil {
+		t.Fatalf("disabled profiler = %#v, want nil", profiler)
+	}
+}
+
+func TestProfilerEnabledWritesDecodableProfiles(t *testing.T) {
+	var output bytes.Buffer
+	profiler, err := StartProfiler(true, &output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = profiler.Stop() })
+
+	// Let the 100 Hz CPU sampler observe the enabled session.
+	time.Sleep(120 * time.Millisecond)
+	if err := profiler.Stop(); err != nil {
+		t.Fatal(err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
+	prefixes := []string{
+		profileCPUPrefix,
+		profileHeapPrefix,
+		profileGoroutinePrefix,
+		profileBlockPrefix,
+		profileMutexPrefix,
+	}
+	if len(lines) != len(prefixes) {
+		t.Fatalf("profile line count = %d, want %d", len(lines), len(prefixes))
+	}
+	for i, prefix := range prefixes {
+		if !strings.HasPrefix(lines[i], prefix) {
+			t.Fatalf("profile line %d = %q, want prefix %q", i, lines[i], prefix)
+		}
+		encoded := strings.TrimPrefix(lines[i], prefix)
+		compressed, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			t.Fatalf("decode %s: %v", prefix, err)
+		}
+		zipper, err := gzip.NewReader(bytes.NewReader(compressed))
+		if err != nil {
+			t.Fatalf("open %s gzip payload: %v", prefix, err)
+		}
+		profile, err := io.ReadAll(zipper)
+		if err != nil {
+			t.Fatalf("read %s gzip payload: %v", prefix, err)
+		}
+		if err := zipper.Close(); err != nil {
+			t.Fatalf("close %s gzip payload: %v", prefix, err)
+		}
+		if len(profile) == 0 {
+			t.Fatalf("%s profile is empty", prefix)
+		}
+		if !bytes.HasPrefix(profile, []byte{0x1f, 0x8b}) {
+			t.Fatalf("%s payload is not a Go gzip-compressed pprof profile", prefix)
+		}
+	}
+
+	before := output.Len()
+	if err := profiler.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	if output.Len() != before {
+		t.Fatal("second Stop wrote duplicate profiles")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -137,6 +137,11 @@ func main() {
 					&cli.IntFlag{Name: "interval", Aliases: []string{"i"}, Required: true},
 					&cli.Int64Flag{Name: "epoch", Required: true},
 					&cli.StringFlag{Name: "job", Required: true},
+					&cli.BoolFlag{
+						Name:    "pprof",
+						Usage:   "capture runtime profiles and emit them as gzip+base64 log lines at exit",
+						EnvVars: []string{"ATOMI_PROBER__PPROF"},
+					},
 				},
 			},
 			{


### PR DESCRIPTION
## Summary

- add a default-off `--pprof` flag with `ATOMI_PROBER__PPROF` support
- capture CPU for the prober action and heap, goroutine, block, and mutex profiles at exit
- enable block and mutex sampling only while profiling is active
- gzip and base64 each profile into a dedicated `PPROF-<TYPE>-B64:` log line for short-lived Job retrieval
- document exact pikachu enable, disable, retrieval, and reconstruction commands

## Verification

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `SKIP=a-golang-ci-lint pre-commit run --all-files`
- reconstructed all five emitted profiles with the documented shell pipeline and parsed each with `go tool pprof`

Phase 2 performance changes are intentionally out of scope pending profiles from a loaded Job.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional runtime profiling for prober jobs through the `--pprof` flag or environment variable.
  * Captures CPU, heap, goroutine, block, and mutex profiles in job logs for later analysis.
  * Profiling is disabled by default.

* **Documentation**
  * Added instructions for enabling profiling, retrieving captured profiles, and analyzing them with Go tools.

* **Bug Fixes**
  * Improved error reporting when profiling cleanup encounters failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->